### PR TITLE
Add pathfinding stubs for vehicle movement

### DIFF
--- a/docs/pathfinding.md
+++ b/docs/pathfinding.md
@@ -1,0 +1,8 @@
+# Pathfinding
+
+The current implementation uses stub functions defined in `sql/procs/pathfinding.sql`.
+These functions return empty paths and are placeholders for a future algorithm.
+
+The intended implementation will use Dijkstra or A* to compute optimal routes
+between coordinates. Once implemented, vehicle movement procedures will be able
+to call `find_route` to obtain a valid path.

--- a/sql/procs/pathfinding.sql
+++ b/sql/procs/pathfinding.sql
@@ -1,0 +1,11 @@
+-- Pathfinding stub functions
+-- TODO: implement Dijkstra or A* algorithm
+
+CREATE OR REPLACE FUNCTION find_route(start_x integer, start_y integer, end_x integer, end_y integer)
+RETURNS integer[][] AS $$
+BEGIN
+    -- Placeholder: returns empty path until algorithm is implemented
+    RETURN ARRAY[]::integer[][];
+END;
+$$ LANGUAGE plpgsql;
+

--- a/sql/procs/vehicle_movement.sql
+++ b/sql/procs/vehicle_movement.sql
@@ -1,0 +1,15 @@
+-- Vehicle movement procedures
+-- Currently uses stubbed pathfinding.
+-- TODO: integrate with real pathfinding (Dijkstra/A*) algorithm.
+
+CREATE OR REPLACE FUNCTION move_vehicle(vehicle_id integer, start_x integer, start_y integer, end_x integer, end_y integer)
+RETURNS void AS $$
+DECLARE
+    path integer[][];
+BEGIN
+    -- Obtain route using stubbed pathfinding
+    path := find_route(start_x, start_y, end_x, end_y);
+    -- Placeholder: movement logic will use path once implemented
+END;
+$$ LANGUAGE plpgsql;
+


### PR DESCRIPTION
## Summary
- add stubbed `find_route` procedure for pathfinding
- reference `find_route` in `move_vehicle` procedure for future algorithms
- document future Dijkstra/A* implementation

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68af64b58b3883289bd3462825443f21