### PR TITLE
Add game initialization and tick procedures

### DIFF
--- a/docs/procs.md
+++ b/docs/procs.md
@@ -1,0 +1,29 @@
+# Stored Procedures
+
+## `new_game(width, height)`
+Initializes a new game world. It wipes any existing state, creates a new
+`game_state` row with tick zero, and fills the `tiles` and `terrain`
+tables with a grid of the supplied dimensions.
+
+Usage:
+```sql
+CALL new_game(10, 10);
+```
+
+## `tick()`
+Advances the global tick counter and updates time-dependent tables such as
+`terrain`.
+
+Usage:
+```sql
+CALL tick();
+```
+
+### Python wrapper
+The script [`scripts/run_tick.py`](../scripts/run_tick.py) calls `tick()` using
+[`psycopg`](https://www.psycopg.org/). Set the `DATABASE_URL` environment
+variable and run:
+
+```bash
+python scripts/run_tick.py
+```

--- a/scripts/run_tick.py
+++ b/scripts/run_tick.py
@@ -1,0 +1,19 @@
+"""Wrapper script to advance the game tick."""
+import os
+import psycopg
+
+
+def main() -> None:
+    """Call the ``tick`` stored procedure."""
+    dsn = os.environ.get("DATABASE_URL")
+    if not dsn:
+        raise RuntimeError("DATABASE_URL environment variable must be set")
+
+    with psycopg.connect(dsn) as conn:
+        with conn.cursor() as cur:
+            cur.execute("CALL tick()")
+        conn.commit()
+
+
+if __name__ == "__main__":
+    main()

--- a/sql/procs/new_game.sql
+++ b/sql/procs/new_game.sql
@@ -1,0 +1,26 @@
+CREATE OR REPLACE PROCEDURE new_game(width INT, height INT)
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    x INT;
+    y INT;
+BEGIN
+    -- Reset world state
+    TRUNCATE TABLE tiles RESTART IDENTITY CASCADE;
+    TRUNCATE TABLE terrain RESTART IDENTITY CASCADE;
+    TRUNCATE TABLE game_state RESTART IDENTITY CASCADE;
+
+    -- Create initial game state
+    INSERT INTO game_state(width, height, current_tick)
+    VALUES (width, height, 0);
+
+    -- Populate tiles and terrain
+    FOR x IN 1..width LOOP
+        FOR y IN 1..height LOOP
+            INSERT INTO tiles(x, y) VALUES (x, y);
+            INSERT INTO terrain(tile_x, tile_y, type)
+            VALUES (x, y, 'plain');
+        END LOOP;
+    END LOOP;
+END;
+$$;

--- a/sql/procs/tick.sql
+++ b/sql/procs/tick.sql
@@ -1,0 +1,15 @@
+CREATE OR REPLACE PROCEDURE tick()
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    new_tick INT;
+BEGIN
+    -- Advance global tick counter
+    UPDATE game_state
+    SET current_tick = current_tick + 1
+    RETURNING current_tick INTO new_tick;
+
+    -- Example time-dependent update: mark terrain with latest tick
+    UPDATE terrain SET updated_tick = new_tick;
+END;
+$$;


### PR DESCRIPTION
## Summary
- define `new_game` procedure to seed tiles, terrain, and game state
- add `tick` procedure to advance global tick and update terrain
- provide `run_tick.py` helper and document stored procedure usage

## Testing
- `python -m py_compile scripts/run_tick.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68af64b00e0c8328a6a980d39d6f63db