### PR TITLE
Add initial database schema and docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,6 @@
+PSQL?=psql
+SCHEMA=sql/schema.sql
+
+.PHONY: apply-schema
+apply-schema:
+	$(PSQL) $(PSQLFLAGS) -f $(SCHEMA)

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -1,0 +1,53 @@
+# Database Schema
+
+The schema defines core tables for representing the game world and simulation state.
+
+## Tables
+
+### `terrain`
+Stores terrain types.
+- `id` — primary key.
+- `name` — human readable name.
+
+### `tiles`
+Represents each map tile.
+- `id` — primary key.
+- `x`, `y` — tile coordinates.
+- `terrain_id` — foreign key to `terrain`.
+- Each `(x, y)` pair is unique.
+
+### `companies`
+Companies owned by players or AI.
+- `id` — primary key.
+- `name` — company name.
+
+### `industries`
+Industry structures placed on tiles.
+- `id` — primary key.
+- `name` — industry name.
+- `tile_id` — foreign key to the tile it occupies.
+- `company_id` — optional owning company.
+
+### `vehicles`
+Movable units controlled by companies.
+- `id` — primary key.
+- `name` — vehicle name.
+- `type` — vehicle type (e.g., train, truck).
+- `tile_id` — current tile position.
+- `company_id` — owning company.
+
+### `game_state`
+Singleton metadata about the running simulation.
+- `id` — primary key for potential multiple saves.
+- `current_tick` — global tick counter.
+- `seed` — world generation seed.
+- `created_at` — timestamp when the state was created.
+
+## Relationships
+- `tiles.terrain_id` → `terrain.id`
+- `industries.tile_id` → `tiles.id`
+- `industries.company_id` → `companies.id`
+- `vehicles.tile_id` → `tiles.id`
+- `vehicles.company_id` → `companies.id`
+
+These relationships enable querying ownership, positions, and terrain context for simulation routines.

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -1,0 +1,41 @@
+-- pg_ttd initial schema
+
+CREATE TABLE IF NOT EXISTS terrain (
+    id SERIAL PRIMARY KEY,
+    name TEXT NOT NULL UNIQUE
+);
+
+CREATE TABLE IF NOT EXISTS tiles (
+    id SERIAL PRIMARY KEY,
+    x INTEGER NOT NULL,
+    y INTEGER NOT NULL,
+    terrain_id INTEGER NOT NULL REFERENCES terrain(id),
+    UNIQUE (x, y)
+);
+
+CREATE TABLE IF NOT EXISTS companies (
+    id SERIAL PRIMARY KEY,
+    name TEXT NOT NULL UNIQUE
+);
+
+CREATE TABLE IF NOT EXISTS industries (
+    id SERIAL PRIMARY KEY,
+    name TEXT NOT NULL,
+    tile_id INTEGER NOT NULL REFERENCES tiles(id),
+    company_id INTEGER REFERENCES companies(id)
+);
+
+CREATE TABLE IF NOT EXISTS vehicles (
+    id SERIAL PRIMARY KEY,
+    name TEXT NOT NULL,
+    type TEXT NOT NULL,
+    tile_id INTEGER NOT NULL REFERENCES tiles(id),
+    company_id INTEGER NOT NULL REFERENCES companies(id)
+);
+
+CREATE TABLE IF NOT EXISTS game_state (
+    id SERIAL PRIMARY KEY,
+    current_tick BIGINT DEFAULT 0,
+    seed BIGINT,
+    created_at TIMESTAMPTZ DEFAULT NOW()
+);


### PR DESCRIPTION
## Summary
- define core game tables for terrain, tiles, companies, industries, vehicles and game_state
- document schema design and relationships
- provide Makefile target to apply schema with psql

## Testing
- `psql --version`
- `make -n apply-schema`
- `psql -f sql/schema.sql` *(fails: connection to server on socket "/var/run/postgresql/.s.PGSQL.5432" failed)*


------
https://chatgpt.com/codex/tasks/task_e_68af64af2088832896c989f258bd3c46