### PR TITLE
Add economy tick procedure and regression tests

### DIFF
--- a/sql/procs/economy_tick.sql
+++ b/sql/procs/economy_tick.sql
@@ -1,0 +1,56 @@
+-- Resource and industry tick processing
+
+-- Table storing current resource amounts
+CREATE TABLE IF NOT EXISTS resources (
+    id SERIAL PRIMARY KEY,
+    name TEXT UNIQUE NOT NULL,
+    amount INTEGER NOT NULL DEFAULT 0
+);
+
+-- Rules describing growth and decay for each resource
+CREATE TABLE IF NOT EXISTS resource_rules (
+    resource_id INTEGER PRIMARY KEY REFERENCES resources(id) ON DELETE CASCADE,
+    growth_rate INTEGER NOT NULL DEFAULT 0,
+    decay_rate INTEGER NOT NULL DEFAULT 0
+);
+
+-- Industries consume one resource to produce another
+CREATE TABLE IF NOT EXISTS industries (
+    id SERIAL PRIMARY KEY,
+    name TEXT UNIQUE NOT NULL,
+    input_resource_id INTEGER REFERENCES resources(id),
+    output_resource_id INTEGER REFERENCES resources(id),
+    input_per_tick INTEGER NOT NULL DEFAULT 0,
+    output_per_tick INTEGER NOT NULL DEFAULT 0
+);
+
+-- Perform a single economy tick. Resources regenerate/decay and
+-- industries consume inputs and produce outputs.
+CREATE OR REPLACE FUNCTION economy_tick() RETURNS VOID AS $$
+BEGIN
+    -- Apply resource growth and decay
+    UPDATE resources r
+    SET amount = GREATEST(0, r.amount + rr.growth_rate - rr.decay_rate)
+    FROM resource_rules rr
+    WHERE rr.resource_id = r.id;
+
+    -- Handle industries that have enough input resources
+    WITH ready AS (
+        SELECT i.id, i.input_resource_id, i.output_resource_id,
+               i.input_per_tick, i.output_per_tick
+        FROM industries i
+        JOIN resources rin ON rin.id = i.input_resource_id
+        WHERE rin.amount >= i.input_per_tick
+    ), consumed AS (
+        UPDATE resources r
+        SET amount = r.amount - ready.input_per_tick
+        FROM ready
+        WHERE r.id = ready.input_resource_id
+        RETURNING ready.output_resource_id, ready.output_per_tick
+    )
+    UPDATE resources r
+    SET amount = r.amount + c.output_per_tick
+    FROM consumed c
+    WHERE r.id = c.output_resource_id;
+END;
+$$ LANGUAGE plpgsql;

--- a/sql/tests/economy_tick.sql
+++ b/sql/tests/economy_tick.sql
@@ -1,0 +1,30 @@
+\set ON_ERROR_STOP on
+
+BEGIN;
+
+-- load procedure definitions
+\ir ../procs/economy_tick.sql
+
+-- setup initial data
+TRUNCATE resources RESTART IDENTITY CASCADE;
+INSERT INTO resources (name, amount) VALUES ('wood', 10), ('goods', 0);
+INSERT INTO resource_rules (resource_id, growth_rate, decay_rate)
+VALUES (1, 2, 0), (2, 0, 0);
+INSERT INTO industries (name, input_resource_id, output_resource_id, input_per_tick, output_per_tick)
+VALUES ('sawmill', 1, 2, 3, 1);
+
+-- execute tick
+SELECT economy_tick();
+
+-- verify results
+DO $$
+BEGIN
+    IF (SELECT amount FROM resources WHERE name='wood') != 9 THEN
+        RAISE EXCEPTION 'wood amount mismatch';
+    END IF;
+    IF (SELECT amount FROM resources WHERE name='goods') != 1 THEN
+        RAISE EXCEPTION 'goods amount mismatch';
+    END IF;
+END$$;
+
+ROLLBACK;


### PR DESCRIPTION
## Summary
- add economy_tick() procedure that regenerates resources and handles industry production
- define tables for resources, resource rules, and industries
- add regression test verifying resource consumption and production per tick

## Testing
- `sudo -u postgres psql -v ON_ERROR_STOP=1 -f sql/tests/economy_tick.sql`


------
https://chatgpt.com/codex/tasks/task_e_68af64b2671483288ba89b3dff0c3f9f