### PR TITLE
Add basic vehicle movement

### DIFF
--- a/docs/vehicles.md
+++ b/docs/vehicles.md
@@ -1,0 +1,15 @@
+# Vehicles
+
+Vehicles move across the map following a sequence of waypoints stored in
+their `schedule` JSON column. Each waypoint is an object of the form
+`{"x": <int>, "y": <int>}`.
+
+`move_vehicles()` advances every vehicle one tile per tick:
+
+1. The next waypoint is read from `schedule[schedule_idx]`.
+2. The vehicle's `x` or `y` coordinate is incremented toward the target by
+   one step.
+3. When the target tile is reached, `schedule_idx` advances to the next
+   waypoint, wrapping to the start when the route is finished.
+
+The procedure ignores vehicles with an empty schedule.

--- a/scripts/create_vehicle.py
+++ b/scripts/create_vehicle.py
@@ -1,0 +1,58 @@
+"""Insert a sample vehicle for testing.
+
+The script connects to a PostgreSQL database using standard libpq
+connection parameters. A JSON array of waypoints is inserted into the
+`schedule` column. Each waypoint must be an object with `x` and `y` keys.
+"""
+
+import argparse
+import json
+import os
+
+import psycopg2
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Create a vehicle")
+    parser.add_argument("--x", type=int, default=0, help="Starting X coordinate")
+    parser.add_argument("--y", type=int, default=0, help="Starting Y coordinate")
+    parser.add_argument(
+        "--schedule",
+        type=str,
+        default="[]",
+        help="JSON array of waypoints, e.g. '[{\"x\":0,\"y\":0},{\"x\":5,\"y\":5}]'",
+    )
+    parser.add_argument("--company-id", type=int, default=None)
+    parser.add_argument(
+        "--cargo",
+        type=str,
+        default="[]",
+        help="JSON description of cargo",
+    )
+    parser.add_argument(
+        "--dsn",
+        type=str,
+        default=os.environ.get("PG_DSN", ""),
+        help="PostgreSQL DSN string",
+    )
+
+    args = parser.parse_args()
+
+    schedule = json.loads(args.schedule)
+    cargo = json.loads(args.cargo)
+
+    conn = psycopg2.connect(args.dsn)
+    with conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                INSERT INTO vehicles (x, y, schedule, cargo, company_id)
+                VALUES (%s, %s, %s::jsonb, %s::jsonb, %s)
+                """,
+                (args.x, args.y, json.dumps(schedule), json.dumps(cargo), args.company_id),
+            )
+    print("Inserted vehicle at", args.x, args.y)
+
+
+if __name__ == "__main__":
+    main()

--- a/sql/procs/move_vehicles.sql
+++ b/sql/procs/move_vehicles.sql
@@ -1,0 +1,53 @@
+-- Procedure to move vehicles one step towards their scheduled waypoints
+CREATE OR REPLACE PROCEDURE move_vehicles()
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    v RECORD;
+    target JSONB;
+    target_x INTEGER;
+    target_y INTEGER;
+    new_x INTEGER;
+    new_y INTEGER;
+    new_idx INTEGER;
+    sched_len INTEGER;
+BEGIN
+    FOR v IN SELECT * FROM vehicles LOOP
+        sched_len := jsonb_array_length(v.schedule);
+        IF sched_len = 0 THEN
+            CONTINUE;
+        END IF;
+
+        IF v.schedule_idx >= sched_len OR v.schedule_idx < 0 THEN
+            new_idx := 0;
+        ELSE
+            new_idx := v.schedule_idx;
+        END IF;
+
+        target := v.schedule -> new_idx;
+        target_x := (target->>'x')::INTEGER;
+        target_y := (target->>'y')::INTEGER;
+
+        new_x := v.x;
+        new_y := v.y;
+
+        IF v.x < target_x THEN
+            new_x := v.x + 1;
+        ELSIF v.x > target_x THEN
+            new_x := v.x - 1;
+        ELSIF v.y < target_y THEN
+            new_y := v.y + 1;
+        ELSIF v.y > target_y THEN
+            new_y := v.y - 1;
+        ELSE
+            new_idx := (new_idx + 1) % sched_len;
+        END IF;
+
+        UPDATE vehicles
+        SET x = new_x,
+            y = new_y,
+            schedule_idx = new_idx
+        WHERE id = v.id;
+    END LOOP;
+END;
+$$;

--- a/sql/tables/companies.sql
+++ b/sql/tables/companies.sql
@@ -1,0 +1,5 @@
+-- Minimal companies table for vehicle ownership
+CREATE TABLE IF NOT EXISTS companies (
+    id SERIAL PRIMARY KEY,
+    name TEXT NOT NULL
+);

--- a/sql/tables/vehicles.sql
+++ b/sql/tables/vehicles.sql
@@ -1,0 +1,10 @@
+-- Table definition for vehicles
+CREATE TABLE IF NOT EXISTS vehicles (
+    id SERIAL PRIMARY KEY,
+    x INTEGER NOT NULL,
+    y INTEGER NOT NULL,
+    schedule JSONB NOT NULL DEFAULT '[]'::jsonb,
+    schedule_idx INTEGER NOT NULL DEFAULT 0,
+    cargo JSONB NOT NULL DEFAULT '[]'::jsonb,
+    company_id INTEGER
+);


### PR DESCRIPTION
## Summary
- define vehicles and companies tables with coordinate, schedule, cargo, and ownership fields
- add `move_vehicles` procedure to advance vehicles one tile toward waypoints each tick
- provide Python helper to insert test vehicles and document movement

## Testing
- ✅ `python -m py_compile scripts/create_vehicle.py`
- ✅ `python scripts/create_vehicle.py --help`
- ⚠️ `psql -f sql/procs/move_vehicles.sql` *(no running Postgres server)*

------
https://chatgpt.com/codex/tasks/task_e_68af64b4e1088328a278daf684a17c9e