### PR TITLE
Add company balance tracking

### DIFF
--- a/docs/finance.md
+++ b/docs/finance.md
@@ -1,0 +1,18 @@
+# Finance
+
+Companies maintain basic accounting fields to track their financial state:
+
+- `cash` – total available money.
+- `income` – earnings generated in the current tick.
+- `expenses` – money spent in the current tick.
+
+The `update_balances()` procedure runs every tick to apply results of industry
+production and vehicle operations:
+
+1. `income` and `expenses` are reset to zero.
+2. Industry output increases both `income` and `cash`.
+3. Vehicle revenue increases `income` and `cash` while operating costs increase
+   `expenses` and reduce `cash`.
+
+Use `reports/balance_sheet.sql` to inspect a company’s current financial
+position.

--- a/reports/balance_sheet.sql
+++ b/reports/balance_sheet.sql
@@ -1,0 +1,9 @@
+-- Retrieve the balance sheet for a single company
+SELECT
+    company_id,
+    name,
+    cash,
+    income,
+    expenses
+FROM companies
+WHERE company_id = :company_id;

--- a/sql/procs/update_balances.sql
+++ b/sql/procs/update_balances.sql
@@ -1,0 +1,35 @@
+-- Adjust company balances based on industry and vehicle activity
+CREATE OR REPLACE FUNCTION update_balances()
+RETURNS VOID AS $$
+BEGIN
+    -- Reset per-tick aggregates
+    UPDATE companies SET income = 0, expenses = 0;
+
+    -- Apply industry output as income
+    UPDATE companies c
+    SET
+        income = income + COALESCE(io.total_output, 0),
+        cash   = cash + COALESCE(io.total_output, 0)
+    FROM (
+        SELECT company_id, SUM(value) AS total_output
+        FROM industry_outputs
+        GROUP BY company_id
+    ) io
+    WHERE io.company_id = c.company_id;
+
+    -- Apply vehicle operations
+    UPDATE companies c
+    SET
+        income   = income + COALESCE(vo.revenue, 0),
+        expenses = expenses + COALESCE(vo.cost, 0),
+        cash     = cash + COALESCE(vo.revenue, 0) - COALESCE(vo.cost, 0)
+    FROM (
+        SELECT company_id,
+               SUM(revenue) AS revenue,
+               SUM(cost) AS cost
+        FROM vehicle_operations
+        GROUP BY company_id
+    ) vo
+    WHERE vo.company_id = c.company_id;
+END;
+$$ LANGUAGE plpgsql;

--- a/sql/schema/companies.sql
+++ b/sql/schema/companies.sql
@@ -1,0 +1,8 @@
+-- Companies table with accounting fields
+CREATE TABLE IF NOT EXISTS companies (
+    company_id SERIAL PRIMARY KEY,
+    name TEXT NOT NULL,
+    cash BIGINT NOT NULL DEFAULT 0,
+    income BIGINT NOT NULL DEFAULT 0,
+    expenses BIGINT NOT NULL DEFAULT 0
+);


### PR DESCRIPTION
## Summary
- add cash, income, and expenses fields to companies table
- update balances each tick using industry output and vehicle costs
- provide balance sheet report and finance documentation

## Testing
- `su - postgres -c "psql -d pg_ttd_test -f /workspace/pg_ttd/sql/schema/companies.sql"`
- `su - postgres -c "psql -d pg_ttd_test -f /workspace/pg_ttd/sql/procs/update_balances.sql"`
- `su - postgres -c "psql -d pg_ttd_test -v company_id=1 -f /workspace/pg_ttd/reports/balance_sheet.sql"`


------
https://chatgpt.com/codex/tasks/task_e_68af64b7a61c832892a8561384c1517a