### PR TITLE
Avoid schema collision between industries and resource industries

### DIFF
--- a/docs/procs.md
+++ b/docs/procs.md
@@ -27,3 +27,13 @@ variable and run:
 ```bash
 python scripts/run_tick.py
 ```
+
+## `economy_tick()`
+Runs the simplified economic simulation. Resource amounts are adjusted by
+`resource_rules` and any `resource_industries` consume input resources to
+produce outputs.
+
+Usage:
+```sql
+SELECT economy_tick();
+```

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -28,6 +28,28 @@ Industry structures placed on tiles.
 - `tile_id` — foreign key to the tile it occupies.
 - `company_id` — optional owning company.
 
+### `resources`
+Tracked quantities for raw materials or goods.
+- `id` — primary key.
+- `name` — unique resource name.
+- `amount` — current stock level.
+
+### `resource_rules`
+Growth and decay rates applied each economy tick.
+- `resource_id` — references the resource.
+- `growth_rate` — amount gained per tick.
+- `decay_rate` — amount lost per tick.
+
+### `resource_industries`
+Lightweight factories that convert one resource into another. These are
+distinct from map `industries` and exist purely in the economic model.
+- `id` — primary key.
+- `name` — unique industry name.
+- `input_resource_id` — resource consumed each tick.
+- `output_resource_id` — resource produced.
+- `input_per_tick` — units of input consumed per tick.
+- `output_per_tick` — units of output produced per tick.
+
 ### `vehicles`
 Movable units controlled by companies.
 - `id` — primary key.
@@ -49,5 +71,8 @@ Singleton metadata about the running simulation.
 - `industries.company_id` → `companies.id`
 - `vehicles.tile_id` → `tiles.id`
 - `vehicles.company_id` → `companies.id`
+- `resource_rules.resource_id` → `resources.id`
+- `resource_industries.input_resource_id` → `resources.id`
+- `resource_industries.output_resource_id` → `resources.id`
 
 These relationships enable querying ownership, positions, and terrain context for simulation routines.

--- a/sql/procs/economy_tick.sql
+++ b/sql/procs/economy_tick.sql
@@ -1,31 +1,7 @@
 -- Resource and industry tick processing
 
--- Table storing current resource amounts
-CREATE TABLE IF NOT EXISTS resources (
-    id SERIAL PRIMARY KEY,
-    name TEXT UNIQUE NOT NULL,
-    amount INTEGER NOT NULL DEFAULT 0
-);
-
--- Rules describing growth and decay for each resource
-CREATE TABLE IF NOT EXISTS resource_rules (
-    resource_id INTEGER PRIMARY KEY REFERENCES resources(id) ON DELETE CASCADE,
-    growth_rate INTEGER NOT NULL DEFAULT 0,
-    decay_rate INTEGER NOT NULL DEFAULT 0
-);
-
--- Industries consume one resource to produce another
-CREATE TABLE IF NOT EXISTS industries (
-    id SERIAL PRIMARY KEY,
-    name TEXT UNIQUE NOT NULL,
-    input_resource_id INTEGER REFERENCES resources(id),
-    output_resource_id INTEGER REFERENCES resources(id),
-    input_per_tick INTEGER NOT NULL DEFAULT 0,
-    output_per_tick INTEGER NOT NULL DEFAULT 0
-);
-
 -- Perform a single economy tick. Resources regenerate/decay and
--- industries consume inputs and produce outputs.
+-- resource industries consume inputs and produce outputs.
 CREATE OR REPLACE FUNCTION economy_tick() RETURNS VOID AS $$
 BEGIN
     -- Apply resource growth and decay
@@ -38,7 +14,7 @@ BEGIN
     WITH ready AS (
         SELECT i.id, i.input_resource_id, i.output_resource_id,
                i.input_per_tick, i.output_per_tick
-        FROM industries i
+        FROM resource_industries i
         JOIN resources rin ON rin.id = i.input_resource_id
         WHERE rin.amount >= i.input_per_tick
     ), consumed AS (

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -39,3 +39,27 @@ CREATE TABLE IF NOT EXISTS game_state (
     seed BIGINT,
     created_at TIMESTAMPTZ DEFAULT NOW()
 );
+
+-- Resources available in the world economy
+CREATE TABLE IF NOT EXISTS resources (
+    id SERIAL PRIMARY KEY,
+    name TEXT UNIQUE NOT NULL,
+    amount INTEGER NOT NULL DEFAULT 0
+);
+
+-- Growth and decay rules for resources
+CREATE TABLE IF NOT EXISTS resource_rules (
+    resource_id INTEGER PRIMARY KEY REFERENCES resources(id) ON DELETE CASCADE,
+    growth_rate INTEGER NOT NULL DEFAULT 0,
+    decay_rate INTEGER NOT NULL DEFAULT 0
+);
+
+-- Industries that transform one resource into another
+CREATE TABLE IF NOT EXISTS resource_industries (
+    id SERIAL PRIMARY KEY,
+    name TEXT UNIQUE NOT NULL,
+    input_resource_id INTEGER REFERENCES resources(id),
+    output_resource_id INTEGER REFERENCES resources(id),
+    input_per_tick INTEGER NOT NULL DEFAULT 0,
+    output_per_tick INTEGER NOT NULL DEFAULT 0
+);

--- a/sql/tests/economy_tick.sql
+++ b/sql/tests/economy_tick.sql
@@ -2,15 +2,16 @@
 
 BEGIN;
 
--- load procedure definitions
+-- load schema and procedure definitions
+\ir ../schema.sql
 \ir ../procs/economy_tick.sql
 
 -- setup initial data
-TRUNCATE resources RESTART IDENTITY CASCADE;
+TRUNCATE resources, resource_rules, resource_industries RESTART IDENTITY CASCADE;
 INSERT INTO resources (name, amount) VALUES ('wood', 10), ('goods', 0);
 INSERT INTO resource_rules (resource_id, growth_rate, decay_rate)
 VALUES (1, 2, 0), (2, 0, 0);
-INSERT INTO industries (name, input_resource_id, output_resource_id, input_per_tick, output_per_tick)
+INSERT INTO resource_industries (name, input_resource_id, output_resource_id, input_per_tick, output_per_tick)
 VALUES ('sawmill', 1, 2, 3, 1);
 
 -- execute tick


### PR DESCRIPTION
## Summary
- Add dedicated `resources`, `resource_rules`, and `resource_industries` tables
- Update `economy_tick` to operate on `resource_industries`
- Document resource economy tables and `economy_tick`

## Testing
- `psql -f sql/tests/economy_tick.sql` *(command not found)*
- `apt-get install -y postgresql-client` *(unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68af66d3c7b08328be96d30c1947dc4e