### PR TITLE
Add A* pathfinding and route tests

### DIFF
--- a/docs/pathfinding.md
+++ b/docs/pathfinding.md
@@ -1,8 +1,7 @@
 # Pathfinding
 
-The current implementation uses stub functions defined in `sql/procs/pathfinding.sql`.
-These functions return empty paths and are placeholders for a future algorithm.
-
-The intended implementation will use Dijkstra or A* to compute optimal routes
-between coordinates. Once implemented, vehicle movement procedures will be able
-to call `find_route` to obtain a valid path.
+`find_route` in `sql/procs/pathfinding.sql` provides a basic A* search across a
+grid using Manhattan distance. The function returns an array of coordinates from
+the start location to the destination. While it currently ignores obstacles and
+terrain costs, it establishes a foundation that can be extended with richer
+world data.

--- a/sql/procs/pathfinding.sql
+++ b/sql/procs/pathfinding.sql
@@ -1,11 +1,93 @@
--- Pathfinding stub functions
--- TODO: implement Dijkstra or A* algorithm
+-- Pathfinding utilities
+-- Implements a simple A* search over a grid using Manhattan distance.
 
-CREATE OR REPLACE FUNCTION find_route(start_x integer, start_y integer, end_x integer, end_y integer)
+CREATE OR REPLACE FUNCTION find_route(start_x integer, start_y integer,
+                                      end_x integer, end_y integer)
 RETURNS integer[][] AS $$
+DECLARE
+    cur_x integer;
+    cur_y integer;
+    cur_cost integer;
+    nbr RECORD;
+    path integer[][] := ARRAY[]::integer[][];
 BEGIN
-    -- Placeholder: returns empty path until algorithm is implemented
-    RETURN ARRAY[]::integer[][];
+    -- Ensure we can run multiple times in a session
+    DROP TABLE IF EXISTS open_set;
+    DROP TABLE IF EXISTS came_from;
+
+    -- Nodes to be explored, ordered by estimated total cost
+    CREATE TEMP TABLE open_set(
+        x      integer,
+        y      integer,
+        cost   integer,
+        pri    integer
+    ) ON COMMIT DROP;
+
+    -- Tracks how we reached each explored node
+    CREATE TEMP TABLE came_from(
+        x       integer,
+        y       integer,
+        prev_x  integer,
+        prev_y  integer,
+        cost    integer,
+        PRIMARY KEY (x, y)
+    ) ON COMMIT DROP;
+
+    INSERT INTO open_set VALUES
+        (start_x, start_y, 0, abs(start_x - end_x) + abs(start_y - end_y));
+    INSERT INTO came_from VALUES (start_x, start_y, NULL, NULL, 0);
+
+    LOOP
+        SELECT x, y, cost INTO cur_x, cur_y, cur_cost
+        FROM open_set
+        ORDER BY pri
+        LIMIT 1;
+
+        -- No path found
+        IF NOT FOUND THEN
+            RETURN ARRAY[]::integer[][];
+        END IF;
+
+        DELETE FROM open_set WHERE x = cur_x AND y = cur_y;
+
+        EXIT WHEN cur_x = end_x AND cur_y = end_y;
+
+        -- Explore four neighbouring tiles
+        FOR nbr IN
+            SELECT cur_x + 1 AS x, cur_y AS y
+            UNION ALL SELECT cur_x - 1, cur_y
+            UNION ALL SELECT cur_x, cur_y + 1
+            UNION ALL SELECT cur_x, cur_y - 1
+        LOOP
+            IF NOT EXISTS (SELECT 1 FROM came_from
+                           WHERE x = nbr.x AND y = nbr.y) THEN
+                INSERT INTO came_from(x, y, prev_x, prev_y, cost)
+                VALUES (nbr.x, nbr.y, cur_x, cur_y, cur_cost + 1);
+                INSERT INTO open_set(x, y, cost, pri)
+                VALUES (
+                    nbr.x, nbr.y, cur_cost + 1,
+                    cur_cost + 1
+                    + abs(nbr.x - end_x) + abs(nbr.y - end_y)
+                );
+            END IF;
+        END LOOP;
+    END LOOP;
+
+    -- Reconstruct path from end to start
+    cur_x := end_x;
+    cur_y := end_y;
+    LOOP
+        path := ARRAY[[cur_x, cur_y]] || path;
+        EXIT WHEN cur_x = start_x AND cur_y = start_y;
+        SELECT prev_x, prev_y INTO cur_x, cur_y
+        FROM came_from WHERE x = cur_x AND y = cur_y;
+        -- Safety: no path recorded
+        IF NOT FOUND THEN
+            RETURN ARRAY[]::integer[][];
+        END IF;
+    END LOOP;
+
+    RETURN path;
 END;
 $$ LANGUAGE plpgsql;
 

--- a/sql/tests/pathfinding.sql
+++ b/sql/tests/pathfinding.sql
@@ -1,0 +1,32 @@
+\set ON_ERROR_STOP on
+
+BEGIN;
+
+-- load function under test
+\ir ../procs/pathfinding.sql
+
+-- verify simple route
+DO $$
+DECLARE
+    res integer[][];
+    expected integer[][] := ARRAY[[1,1],[2,1],[3,1],[3,2]];
+BEGIN
+    res := find_route(1,1,3,2);
+    IF res IS NULL OR res != expected THEN
+        RAISE EXCEPTION 'route mismatch: %', res;
+    END IF;
+END$$;
+
+-- verify start equals end
+DO $$
+DECLARE
+    res integer[][];
+    expected integer[][] := ARRAY[[2,2]];
+BEGIN
+    res := find_route(2,2,2,2);
+    IF res IS NULL OR res != expected THEN
+        RAISE EXCEPTION 'single tile route mismatch: %', res;
+    END IF;
+END$$;
+
+ROLLBACK;


### PR DESCRIPTION
## Summary
- implement A* grid search in `find_route` replacing placeholder
- document pathfinding function
- add SQL tests verifying route generation

## Testing
- `sudo -u postgres psql -v ON_ERROR_STOP=1 -f sql/tests/pathfinding.sql`
- `sudo -u postgres psql -v ON_ERROR_STOP=1 -f sql/tests/economy_tick.sql`


------
https://chatgpt.com/codex/tasks/task_e_68af66ccf708832885359dca7ded0a66