### PR TITLE
Safely quote sprite insert SQL

### DIFF
--- a/tests/test_generate_sprites.py
+++ b/tests/test_generate_sprites.py
@@ -1,0 +1,23 @@
+import importlib.util
+import sqlite3
+from pathlib import Path
+
+
+spec = importlib.util.spec_from_file_location(
+    "generate_sprites", Path(__file__).resolve().parents[1] / "tools" / "generate_sprites.py"
+)
+module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)
+
+
+def test_insert_statement_is_escaped(tmp_path):
+    malicious_name = "evil'); DROP TABLE sprites; --"
+    payload = "data"
+    sql = module.insert_statement(malicious_name, payload)
+
+    conn = sqlite3.connect(":memory:")
+    conn.execute("CREATE TABLE sprites(name TEXT, image_base64 TEXT)")
+    conn.executescript(sql)
+
+    rows = conn.execute("SELECT name, image_base64 FROM sprites").fetchall()
+    assert rows == [(malicious_name, payload)]

--- a/tools/generate_sprites.py
+++ b/tools/generate_sprites.py
@@ -18,6 +18,20 @@ import zlib
 from pathlib import Path
 from typing import Dict, Tuple
 
+
+def quote_sql(value: str) -> str:
+    """Return a safely quoted SQL string literal."""
+    return "'" + value.replace("'", "''") + "'"
+
+
+def insert_statement(name: str, b64: str) -> str:
+    """Return an INSERT statement for the sprites table."""
+    return (
+        "INSERT INTO sprites(name, image_base64) VALUES ({name}, {b64});".format(
+            name=quote_sql(name), b64=quote_sql(b64)
+        )
+    )
+
 # Basic palette of sprite colors.
 PALETTE: Dict[str, Tuple[int, int, int]] = {
     "red": (255, 0, 0),
@@ -90,11 +104,7 @@ def main() -> None:
     args.output.parent.mkdir(parents=True, exist_ok=True)
     with args.output.open("w", encoding="utf-8") as f:
         for name, b64 in sprites.items():
-            f.write(
-                "INSERT INTO sprites(name, image_base64) VALUES ('{name}', '{b64}');\n".format(
-                    name=name, b64=b64
-                )
-            )
+            f.write(insert_statement(name, b64) + "\n")
     print(f"Wrote {len(sprites)} sprites to {args.output}")
 
 


### PR DESCRIPTION
## Summary
- Escape values when generating sprite seed INSERT statements
- Add test ensuring SQL executes without injection

## Testing
- `pytest -q`
- `python tools/generate_sprites.py -o /tmp/test.sql`


------
https://chatgpt.com/codex/tasks/task_e_68af66ca9f6c832894ab29ed844155fb