### PR TITLE
Standardize database scripts on psycopg

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,19 @@ We attempt to reproduce at least part of OpenTTD within a Postgres database.
 That is, all simulation, logic—world generation, tile updates, entities, economics, etc
 is implemented as stored procedures and tables in PostgreSQL.
 
+## Requirements
+
+Python utilities in this repository use the [`psycopg`](https://www.psycopg.org/psycopg3/) driver to
+connect to PostgreSQL. Install the dependencies with:
+
+```bash
+pip install -r requirements.txt
+```
+
+Scripts such as `scripts/run_tick.py` and `scripts/create_vehicle.py` expect a
+PostgreSQL connection string via the `--dsn` option or the `DATABASE_URL`
+environment variable.
+
 ## Renderer
 
 A tiny curses-based renderer is included to visualise the map stored in

--- a/renderer/cli_viewer.py
+++ b/renderer/cli_viewer.py
@@ -19,7 +19,7 @@ from dataclasses import dataclass
 from typing import Dict, Iterable, Tuple
 
 import curses
-import psycopg2
+import psycopg
 
 # ---------------------------------------------------------------------------
 # Database helpers
@@ -128,7 +128,7 @@ def main(stdscr) -> None:
     curses.curs_set(0)
     stdscr.nodelay(True)
     config = load_config()
-    conn = psycopg2.connect(**config)
+    conn = psycopg.connect(**config)
     try:
         while True:
             tiles = list(fetch_tiles(conn))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+psycopg[binary]

--- a/scripts/run_tick.py
+++ b/scripts/run_tick.py
@@ -1,15 +1,25 @@
 """Wrapper script to advance the game tick."""
+import argparse
 import os
+
 import psycopg
 
 
 def main() -> None:
     """Call the ``tick`` stored procedure."""
-    dsn = os.environ.get("DATABASE_URL")
-    if not dsn:
-        raise RuntimeError("DATABASE_URL environment variable must be set")
+    parser = argparse.ArgumentParser(description="Advance the game tick")
+    parser.add_argument(
+        "--dsn",
+        type=str,
+        default=os.environ.get("DATABASE_URL", ""),
+        help="PostgreSQL DSN; defaults to DATABASE_URL env var",
+    )
+    args = parser.parse_args()
 
-    with psycopg.connect(dsn) as conn:
+    if not args.dsn:
+        raise RuntimeError("Database DSN must be provided via --dsn or DATABASE_URL")
+
+    with psycopg.connect(args.dsn) as conn:
         with conn.cursor() as cur:
             cur.execute("CALL tick()")
         conn.commit()


### PR DESCRIPTION
## Summary
- use psycopg v3 for all Python database connections
- unify DSN handling in scripts via `--dsn`/`DATABASE_URL`
- document psycopg dependency and add requirements file

## Testing
- `python -m py_compile scripts/create_vehicle.py scripts/run_tick.py renderer/cli_viewer.py`
- `python scripts/run_tick.py --help`
- `python scripts/create_vehicle.py --help`


------
https://chatgpt.com/codex/tasks/task_e_68af66c8852c8328933017133e7f9782