### PR TITLE
Use CALL for tick stored procedure in renderer

### DIFF
--- a/renderer/cli_viewer.py
+++ b/renderer/cli_viewer.py
@@ -82,7 +82,7 @@ def advance_tick(conn) -> None:
     """Advance the simulation by calling the `tick` stored procedure."""
     with conn.cursor() as cur:
         try:
-            cur.execute("SELECT tick()");
+            cur.execute("CALL tick()");
             conn.commit()
         except Exception:
             conn.rollback()


### PR DESCRIPTION
## Summary
- use `CALL tick()` instead of `SELECT tick()` when advancing simulation

## Testing
- `python -m py_compile renderer/cli_viewer.py`
- `python - <<'PY' ... advance_tick(DummyConn()) ... PY`

------
https://chatgpt.com/codex/tasks/task_e_68af66c115cc83289ce1f16fa3c0313f