### PR TITLE
Add CI workflow with tests and coverage

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,26 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v4
+      with:
+        python-version: '3.x'
+    - name: Install dependencies
+      run: pip install pytest pytest-cov
+    - name: Run tests
+      run: pytest --cov=tools --cov-report=xml --cov-report=term
+    - name: Upload coverage report
+      uses: actions/upload-artifact@v3
+      with:
+        name: coverage-report
+        path: coverage.xml

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,2 @@
+pytest
+pytest-cov

--- a/tests/test_generate_sprites.py
+++ b/tests/test_generate_sprites.py
@@ -1,0 +1,23 @@
+import base64
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from tools import generate_sprites
+
+PNG_SIGNATURE = b"\x89PNG\r\n\x1a\n"
+EXPECTED_RED = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR4nGP4z8AAAAMBAQDJ/pLvAAAAAElFTkSuQmCC"
+
+
+def test_png_from_palette_stdlib_signature():
+    data = generate_sprites._png_from_palette_stdlib((1, 2, 3))
+    assert data.startswith(PNG_SIGNATURE)
+
+
+def test_generate_palette_fallback(monkeypatch):
+    monkeypatch.setitem(sys.modules, "PIL", None)
+    palette = generate_sprites.generate_palette()
+    assert palette["red"] == EXPECTED_RED
+    # ensure base64 decodes to a PNG file
+    png = base64.b64decode(palette["red"])
+    assert png.startswith(PNG_SIGNATURE)

--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -1,0 +1,1 @@
+"""Utility scripts for pg_ttd."""


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to run pytest with coverage and upload report
- test sprite generation utilities
- document test dependencies in `requirements-dev.txt`

## Testing
- `pytest --cov=tools --cov-report=xml --cov-report=term`

------
https://chatgpt.com/codex/tasks/task_e_68af66965db48328829712538459b85a