### PR TITLE
Add finance tables and update balances

### DIFF
--- a/docs/finance.md
+++ b/docs/finance.md
@@ -6,6 +6,10 @@ Companies maintain basic accounting fields to track their financial state:
 - `income` – earnings generated in the current tick.
 - `expenses` – money spent in the current tick.
 
+Industry production and vehicle activity are recorded in the `industry_outputs`
+and `vehicle_operations` tables respectively. Each row in these tables captures
+the results for a single company during the current tick.
+
 The `update_balances()` procedure runs every tick to apply results of industry
 production and vehicle operations:
 

--- a/sql/procs/update_balances.sql
+++ b/sql/procs/update_balances.sql
@@ -15,7 +15,7 @@ BEGIN
         FROM industry_outputs
         GROUP BY company_id
     ) io
-    WHERE io.company_id = c.company_id;
+    WHERE io.company_id = c.id;
 
     -- Apply vehicle operations
     UPDATE companies c
@@ -30,6 +30,6 @@ BEGIN
         FROM vehicle_operations
         GROUP BY company_id
     ) vo
-    WHERE vo.company_id = c.company_id;
+    WHERE vo.company_id = c.id;
 END;
 $$ LANGUAGE plpgsql;

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -15,7 +15,10 @@ CREATE TABLE IF NOT EXISTS tiles (
 
 CREATE TABLE IF NOT EXISTS companies (
     id SERIAL PRIMARY KEY,
-    name TEXT NOT NULL UNIQUE
+    name TEXT NOT NULL UNIQUE,
+    cash INTEGER NOT NULL DEFAULT 0,
+    income INTEGER NOT NULL DEFAULT 0,
+    expenses INTEGER NOT NULL DEFAULT 0
 );
 
 CREATE TABLE IF NOT EXISTS industries (
@@ -31,6 +34,19 @@ CREATE TABLE IF NOT EXISTS vehicles (
     type TEXT NOT NULL,
     tile_id INTEGER NOT NULL REFERENCES tiles(id),
     company_id INTEGER NOT NULL REFERENCES companies(id)
+);
+
+CREATE TABLE IF NOT EXISTS industry_outputs (
+    id SERIAL PRIMARY KEY,
+    company_id INTEGER NOT NULL REFERENCES companies(id),
+    value INTEGER NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS vehicle_operations (
+    id SERIAL PRIMARY KEY,
+    company_id INTEGER NOT NULL REFERENCES companies(id),
+    revenue INTEGER NOT NULL,
+    cost INTEGER NOT NULL
 );
 
 CREATE TABLE IF NOT EXISTS game_state (

--- a/sql/tables/companies.sql
+++ b/sql/tables/companies.sql
@@ -1,5 +1,8 @@
 -- Minimal companies table for vehicle ownership
 CREATE TABLE IF NOT EXISTS companies (
     id SERIAL PRIMARY KEY,
-    name TEXT NOT NULL
+    name TEXT NOT NULL,
+    cash INTEGER NOT NULL DEFAULT 0,
+    income INTEGER NOT NULL DEFAULT 0,
+    expenses INTEGER NOT NULL DEFAULT 0
 );

--- a/sql/tables/industry_outputs.sql
+++ b/sql/tables/industry_outputs.sql
@@ -1,0 +1,7 @@
+-- Temporary storage for industry production results per tick
+CREATE TABLE IF NOT EXISTS industry_outputs (
+    id SERIAL PRIMARY KEY,
+    company_id INTEGER NOT NULL,
+    value INTEGER NOT NULL
+);
+

--- a/sql/tables/vehicle_operations.sql
+++ b/sql/tables/vehicle_operations.sql
@@ -1,0 +1,8 @@
+-- Temporary storage for vehicle revenue and costs per tick
+CREATE TABLE IF NOT EXISTS vehicle_operations (
+    id SERIAL PRIMARY KEY,
+    company_id INTEGER NOT NULL,
+    revenue INTEGER NOT NULL,
+    cost INTEGER NOT NULL
+);
+


### PR DESCRIPTION
## Summary
- expand `companies` table with cash, income, and expenses
- add `industry_outputs` and `vehicle_operations` tables
- fix `update_balances` procedure and document financial data flow

## Testing
- `make apply-schema` *(fails: psql: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68af66c2a7b48328809748eb211b57a6