### PR TITLE
Use id instead of company_id in balance sheet report

### DIFF
--- a/reports/balance_sheet.sql
+++ b/reports/balance_sheet.sql
@@ -1,9 +1,9 @@
 -- Retrieve the balance sheet for a single company
 SELECT
-    company_id,
+    id,
     name,
     cash,
     income,
     expenses
 FROM companies
-WHERE company_id = :company_id;
+WHERE id = :id;

--- a/sql/procs/update_balances.sql
+++ b/sql/procs/update_balances.sql
@@ -15,7 +15,7 @@ BEGIN
         FROM industry_outputs
         GROUP BY company_id
     ) io
-    WHERE io.company_id = c.company_id;
+    WHERE io.company_id = c.id;
 
     -- Apply vehicle operations
     UPDATE companies c
@@ -30,6 +30,6 @@ BEGIN
         FROM vehicle_operations
         GROUP BY company_id
     ) vo
-    WHERE vo.company_id = c.company_id;
+    WHERE vo.company_id = c.id;
 END;
 $$ LANGUAGE plpgsql;

--- a/sql/schema/companies.sql
+++ b/sql/schema/companies.sql
@@ -1,6 +1,6 @@
 -- Companies table with accounting fields
 CREATE TABLE IF NOT EXISTS companies (
-    company_id SERIAL PRIMARY KEY,
+    id SERIAL PRIMARY KEY,
     name TEXT NOT NULL,
     cash BIGINT NOT NULL DEFAULT 0,
     income BIGINT NOT NULL DEFAULT 0,


### PR DESCRIPTION
## Summary
- Query balance sheet report by `id` rather than `company_id`
- Update balance update procedure to join on `companies.id`
- Rename company primary key in schema fragment to `id`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68af66c64ef883288f899e66e393f6d7