### PR TITLE
Add Postgres coverage report

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ jobs:
       with:
         python-version: '3.x'
     - name: Install dependencies
-      run: pip install pytest pytest-cov
+      run: pip install -r requirements.txt -r requirements-dev.txt
     - name: Run tests
       run: pytest --cov=tools --cov-report=xml --cov-report=term
     - name: Upload coverage report
@@ -24,3 +24,21 @@ jobs:
       with:
         name: coverage-report
         path: coverage.xml
+    - name: Install PostgreSQL and plpgsql_check
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y postgresql postgresql-16-plpgsql-check
+        sudo pg_ctlcluster 16 main start
+    - name: Run SQL tests and collect coverage
+      run: |
+        sudo -u postgres psql -c "CREATE EXTENSION IF NOT EXISTS plpgsql_check" postgres
+        export PGOPTIONS='-c plpgsql_check.profiler=on'
+        for f in sql/tests/*.sql; do
+          sudo -u postgres psql -v ON_ERROR_STOP=1 -f "$f" postgres
+        done
+        python scripts/postgres_coverage.py --dsn "postgresql://postgres@localhost/postgres"
+    - name: Upload Postgres coverage
+      uses: actions/upload-artifact@v4
+      with:
+        name: postgres-coverage
+        path: postgres-coverage.csv

--- a/scripts/postgres_coverage.py
+++ b/scripts/postgres_coverage.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""Generate PL/pgSQL coverage report using the plpgsql_check extension.
+
+This utility connects to a PostgreSQL database, retrieves coverage metrics for
+all user-defined PL/pgSQL functions and writes them to a CSV file.
+The plpgsql_check extension must be installed and the profiler enabled during
+execution of tests. Run your SQL tests prior to invoking this script.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+from typing import List, Tuple
+
+import psycopg
+
+
+def collect_coverage(dsn: str) -> List[Tuple[str, float, float]]:
+    """Return coverage metrics for all PL/pgSQL functions."""
+    query = """
+        SELECT
+            n.nspname || '.' || p.proname AS function,
+            plpgsql_coverage_statements(p.oid::regprocedure) AS stmt_cov,
+            plpgsql_coverage_branches(p.oid::regprocedure) AS branch_cov
+        FROM pg_proc p
+        JOIN pg_namespace n ON n.oid = p.pronamespace
+        JOIN pg_language l ON l.oid = p.prolang
+        WHERE l.lanname = 'plpgsql'
+          AND n.nspname NOT LIKE 'pg%'
+          AND n.nspname <> 'information_schema'
+        ORDER BY 1
+    """
+    with psycopg.connect(dsn) as conn:
+        with conn.cursor() as cur:
+            cur.execute("CREATE EXTENSION IF NOT EXISTS plpgsql_check")
+            cur.execute(query)
+            rows = cur.fetchall()
+    return [(func, float(stmt), float(branch)) for func, stmt, branch in rows]
+
+
+def write_csv(rows: List[Tuple[str, float, float]], path: str) -> None:
+    with open(path, "w", newline="") as f:
+        writer = csv.writer(f)
+        writer.writerow(["function", "statement_coverage", "branch_coverage"])
+        writer.writerows(rows)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Generate Postgres coverage report")
+    parser.add_argument("--dsn", required=True, help="PostgreSQL connection string")
+    parser.add_argument(
+        "--output",
+        default="postgres-coverage.csv",
+        help="Path to write CSV report",
+    )
+    args = parser.parse_args()
+
+    rows = collect_coverage(args.dsn)
+    write_csv(rows, args.output)
+
+    for func, stmt_cov, branch_cov in rows:
+        print(f"{func}: statements {stmt_cov:.0%} branches {branch_cov:.0%}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- collect PL/pgSQL coverage metrics via new `postgres_coverage.py` utility
- run SQL tests with profiler enabled and upload Postgres coverage in CI

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68af6f176f408328b9cffa1999e4e3cb