### PR TITLE
Add standard Python .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,29 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# Distribution / packaging
+build/
+dist/
+*.egg-info/
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.pytest_cache/
+*.log
+
+# Virtual environments
+.venv/
+venv/
+env/
+
+# IDEs and editors
+.vscode/
+.idea/
+
+# OS generated files
+.DS_Store
+


### PR DESCRIPTION
## Summary
- add `.gitignore` to exclude common Python artifacts, virtual environments, test outputs, and OS files

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68af7560f81c83289864940592558477