### PR TITLE
docs: document economy_tick and move_vehicles procedures

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,13 @@ Scripts such as `scripts/run_tick.py` and `scripts/create_vehicle.py` expect a
 PostgreSQL connection string via the `--dsn` option or the `DATABASE_URL`
 environment variable.
 
+## Stored procedures
+
+Documentation for the SQL procedures lives in [docs/procs.md](docs/procs.md). Notable
+entries include [`economy_tick()`](docs/procs.md#economy_tick) for economic updates
+and [`move_vehicles()`](docs/procs.md#move_vehicles) which advances vehicles along
+their routes.
+
 ## Renderer
 
 A tiny curses-based renderer is included to visualise the map stored in

--- a/docs/procs.md
+++ b/docs/procs.md
@@ -37,3 +37,29 @@ Usage:
 ```sql
 SELECT economy_tick();
 ```
+
+For a self-contained example see
+[`sql/tests/economy_tick.sql`](../sql/tests/economy_tick.sql). That test seeds the
+`resources`, `resource_rules` and `resource_industries` tables then invokes
+`economy_tick()`. After the call, the wood resource drops from `10` to `9` while
+goods increase from `0` to `1`, demonstrating both growth rules and industry
+production.
+
+The procedure is defined in
+[`sql/procs/economy_tick.sql`](../sql/procs/economy_tick.sql).
+
+## `move_vehicles()`
+Advances every vehicle one tile toward its current scheduled waypoint. When a
+vehicle reaches its target, the `schedule_idx` wraps to the next waypoint in its
+`schedule`.
+
+Usage:
+```sql
+CALL move_vehicles();
+```
+
+Each call updates the `x`, `y` and `schedule_idx` columns of every row in the
+`vehicles` table. The implementation lives in
+[`sql/procs/move_vehicles.sql`](../sql/procs/move_vehicles.sql). The script
+[`scripts/benchmark_move_vehicles.py`](../scripts/benchmark_move_vehicles.py)
+populates test data and measures the performance of this procedure.


### PR DESCRIPTION
## Summary
- expand `economy_tick()` section with example usage and links to SQL procedure and test
- document `move_vehicles()` procedure and reference benchmarking script
- cross-link new procedure docs from README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af769af0448328b0a1b620d3bba09c