### PR TITLE
Add vehicle position and schedule index constraints

### DIFF
--- a/sql/tables/vehicles.sql
+++ b/sql/tables/vehicles.sql
@@ -3,8 +3,14 @@ CREATE TABLE IF NOT EXISTS vehicles (
     id SERIAL PRIMARY KEY,
     x INTEGER NOT NULL,
     y INTEGER NOT NULL,
+    CONSTRAINT non_negative_position CHECK (x >= 0 AND y >= 0),
     schedule JSONB NOT NULL DEFAULT '[]'::JSONB,
     schedule_idx INTEGER NOT NULL DEFAULT 0,
+    CONSTRAINT schedule_idx_within_bounds
+    CHECK (
+        schedule_idx >= 0
+        AND schedule_idx < GREATEST(JSONB_ARRAY_LENGTH(schedule), 1)
+    ),
     cargo JSONB NOT NULL DEFAULT '[]'::JSONB,
     company_id INTEGER
 );

--- a/sql/tests/vehicles.sql
+++ b/sql/tests/vehicles.sql
@@ -1,0 +1,58 @@
+\set ON_ERROR_STOP on
+
+BEGIN;
+
+-- load table definition
+\ir ../tables/vehicles.sql
+
+-- negative position should fail
+DO $$
+BEGIN
+    BEGIN
+        INSERT INTO vehicles (x, y) VALUES (-1, 0);
+        RAISE EXCEPTION 'negative x allowed';
+    EXCEPTION WHEN others THEN
+        NULL;
+    END;
+    BEGIN
+        INSERT INTO vehicles (x, y) VALUES (0, -1);
+        RAISE EXCEPTION 'negative y allowed';
+    EXCEPTION WHEN others THEN
+        NULL;
+    END;
+END$$;
+
+-- schedule_idx out of bounds on insert
+DO $$
+BEGIN
+    BEGIN
+        INSERT INTO vehicles (x, y, schedule, schedule_idx)
+        VALUES (0, 0, '[{"x":1,"y":1}]', 2);
+        RAISE EXCEPTION 'schedule_idx insert out of bounds allowed';
+    EXCEPTION WHEN others THEN
+        NULL;
+    END;
+    BEGIN
+        INSERT INTO vehicles (x, y, schedule, schedule_idx)
+        VALUES (0, 0, '[]', 1);
+        RAISE EXCEPTION 'schedule_idx insert out of bounds for empty schedule allowed';
+    EXCEPTION WHEN others THEN
+        NULL;
+    END;
+END$$;
+
+-- schedule_idx out of bounds on update
+INSERT INTO vehicles (x, y, schedule, schedule_idx)
+VALUES (0, 0, '[{"x":1,"y":1},{"x":2,"y":2}]', 0);
+
+DO $$
+BEGIN
+    BEGIN
+        UPDATE vehicles SET schedule_idx = 2 WHERE id = 1;
+        RAISE EXCEPTION 'schedule_idx update out of bounds allowed';
+    EXCEPTION WHEN others THEN
+        NULL;
+    END;
+END$$;
+
+ROLLBACK;


### PR DESCRIPTION
## Summary
- ensure vehicle positions are non-negative
- validate schedule index stays within its JSON array bounds
- add SQL tests for invalid positions and schedule indexes

## Testing
- `pre-commit run --files sql/tables/vehicles.sql sql/tests/vehicles.sql`
- `sudo -u postgres psql -f sql/tests/vehicles.sql`
- `sudo -u postgres psql -f sql/tests/pathfinding.sql`
- `sudo -u postgres psql -f sql/tests/economy_tick.sql`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68af76996898832883126c9b24039154