### PR TITLE
Consolidate schema management

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,10 @@
 PSQL?=psql
 SCHEMA=sql/schema.sql
 
+.PHONY: generate-schema
+generate-schema:
+	python scripts/generate_schema.py
+
 .PHONY: apply-schema
 apply-schema:
 	$(PSQL) $(PSQLFLAGS) -f $(SCHEMA)

--- a/README.md
+++ b/README.md
@@ -18,6 +18,17 @@ Scripts such as `scripts/run_tick.py` and `scripts/create_vehicle.py` expect a
 PostgreSQL connection string via the `--dsn` option or the `DATABASE_URL`
 environment variable.
 
+## Schema
+
+Individual table definitions live in `sql/tables/`. Run the generator to
+combine them into `sql/schema.sql` before applying the schema:
+
+```bash
+make generate-schema
+```
+
+Edit the per-table files rather than `schema.sql` to avoid divergence.
+
 ## Renderer
 
 A tiny curses-based renderer is included to visualise the map stored in

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -2,6 +2,10 @@
 
 The schema defines core tables for representing the game world and simulation state.
 
+Per-table SQL files are stored in `sql/tables/`. Use `make generate-schema` to
+rebuild the combined `sql/schema.sql` before loading the schema into a
+database.
+
 ## Tables
 
 ### `terrain`

--- a/scripts/generate_schema.py
+++ b/scripts/generate_schema.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+"""Generate sql/schema.sql from individual table definitions.
+
+This script concatenates SQL files in ``sql/tables`` in dependency order to
+produce ``sql/schema.sql``. Edit the per-table files and re-run this script to
+update the combined schema.
+"""
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+TABLES_DIR = ROOT / "sql" / "tables"
+SCHEMA_PATH = ROOT / "sql" / "schema.sql"
+
+# Ordered list to satisfy foreign key dependencies
+TABLE_ORDER = [
+    "terrain",
+    "tiles",
+    "companies",
+    "industries",
+    "vehicles",
+    "industry_outputs",
+    "vehicle_operations",
+    "game_state",
+    "resources",
+    "resource_rules",
+    "resource_industries",
+]
+
+def main() -> None:
+    with SCHEMA_PATH.open("w") as schema:
+        schema.write("-- Auto-generated; do not edit directly.\n\n")
+        for name in TABLE_ORDER:
+            path = TABLES_DIR / f"{name}.sql"
+            text = path.read_text()
+            schema.write(text)
+            if not text.endswith("\n"):
+                schema.write("\n")
+            schema.write("\n")
+
+if __name__ == "__main__":
+    main()

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -1,10 +1,12 @@
--- pg_ttd initial schema
+-- Auto-generated; do not edit directly.
 
+-- Table definition for terrain types
 CREATE TABLE IF NOT EXISTS terrain (
     id SERIAL PRIMARY KEY,
     name TEXT NOT NULL UNIQUE
 );
 
+-- Grid tiles referencing terrain
 CREATE TABLE IF NOT EXISTS tiles (
     id SERIAL PRIMARY KEY,
     x INTEGER NOT NULL,
@@ -13,6 +15,7 @@ CREATE TABLE IF NOT EXISTS tiles (
     UNIQUE (x, y)
 );
 
+-- Companies table for vehicle ownership and accounting
 CREATE TABLE IF NOT EXISTS companies (
     id SERIAL PRIMARY KEY,
     name TEXT NOT NULL UNIQUE,
@@ -21,6 +24,7 @@ CREATE TABLE IF NOT EXISTS companies (
     expenses INTEGER NOT NULL DEFAULT 0
 );
 
+-- Industry structures placed on tiles
 CREATE TABLE IF NOT EXISTS industries (
     id SERIAL PRIMARY KEY,
     name TEXT NOT NULL,
@@ -28,20 +32,25 @@ CREATE TABLE IF NOT EXISTS industries (
     company_id INTEGER REFERENCES companies (id)
 );
 
+-- Table definition for vehicles
 CREATE TABLE IF NOT EXISTS vehicles (
     id SERIAL PRIMARY KEY,
-    name TEXT NOT NULL,
-    type TEXT NOT NULL,
-    tile_id INTEGER NOT NULL REFERENCES tiles (id),
-    company_id INTEGER NOT NULL REFERENCES companies (id)
+    x INTEGER NOT NULL,
+    y INTEGER NOT NULL,
+    schedule JSONB NOT NULL DEFAULT '[]'::JSONB,
+    schedule_idx INTEGER NOT NULL DEFAULT 0,
+    cargo JSONB NOT NULL DEFAULT '[]'::JSONB,
+    company_id INTEGER REFERENCES companies (id)
 );
 
+-- Temporary storage for industry production results per tick
 CREATE TABLE IF NOT EXISTS industry_outputs (
     id SERIAL PRIMARY KEY,
     company_id INTEGER NOT NULL REFERENCES companies (id),
     value INTEGER NOT NULL
 );
 
+-- Temporary storage for vehicle revenue and costs per tick
 CREATE TABLE IF NOT EXISTS vehicle_operations (
     id SERIAL PRIMARY KEY,
     company_id INTEGER NOT NULL REFERENCES companies (id),
@@ -49,6 +58,7 @@ CREATE TABLE IF NOT EXISTS vehicle_operations (
     cost INTEGER NOT NULL
 );
 
+-- Singleton game state metadata
 CREATE TABLE IF NOT EXISTS game_state (
     id SERIAL PRIMARY KEY,
     current_tick BIGINT DEFAULT 0,
@@ -79,3 +89,4 @@ CREATE TABLE IF NOT EXISTS resource_industries (
     input_per_tick INTEGER NOT NULL DEFAULT 0,
     output_per_tick INTEGER NOT NULL DEFAULT 0
 );
+

--- a/sql/schema/companies.sql
+++ b/sql/schema/companies.sql
@@ -1,8 +1,0 @@
--- Companies table with accounting fields
-CREATE TABLE IF NOT EXISTS companies (
-    id SERIAL PRIMARY KEY,
-    name TEXT NOT NULL,
-    cash BIGINT NOT NULL DEFAULT 0,
-    income BIGINT NOT NULL DEFAULT 0,
-    expenses BIGINT NOT NULL DEFAULT 0
-);

--- a/sql/tables/companies.sql
+++ b/sql/tables/companies.sql
@@ -1,7 +1,7 @@
--- Minimal companies table for vehicle ownership
+-- Companies table for vehicle ownership and accounting
 CREATE TABLE IF NOT EXISTS companies (
     id SERIAL PRIMARY KEY,
-    name TEXT NOT NULL,
+    name TEXT NOT NULL UNIQUE,
     cash INTEGER NOT NULL DEFAULT 0,
     income INTEGER NOT NULL DEFAULT 0,
     expenses INTEGER NOT NULL DEFAULT 0

--- a/sql/tables/game_state.sql
+++ b/sql/tables/game_state.sql
@@ -1,0 +1,7 @@
+-- Singleton game state metadata
+CREATE TABLE IF NOT EXISTS game_state (
+    id SERIAL PRIMARY KEY,
+    current_tick BIGINT DEFAULT 0,
+    seed BIGINT,
+    created_at TIMESTAMPTZ DEFAULT NOW()
+);

--- a/sql/tables/industries.sql
+++ b/sql/tables/industries.sql
@@ -1,0 +1,7 @@
+-- Industry structures placed on tiles
+CREATE TABLE IF NOT EXISTS industries (
+    id SERIAL PRIMARY KEY,
+    name TEXT NOT NULL,
+    tile_id INTEGER NOT NULL REFERENCES tiles (id),
+    company_id INTEGER REFERENCES companies (id)
+);

--- a/sql/tables/industry_outputs.sql
+++ b/sql/tables/industry_outputs.sql
@@ -1,6 +1,6 @@
 -- Temporary storage for industry production results per tick
 CREATE TABLE IF NOT EXISTS industry_outputs (
     id SERIAL PRIMARY KEY,
-    company_id INTEGER NOT NULL,
+    company_id INTEGER NOT NULL REFERENCES companies (id),
     value INTEGER NOT NULL
 );

--- a/sql/tables/resource_industries.sql
+++ b/sql/tables/resource_industries.sql
@@ -1,0 +1,9 @@
+-- Industries that transform one resource into another
+CREATE TABLE IF NOT EXISTS resource_industries (
+    id SERIAL PRIMARY KEY,
+    name TEXT UNIQUE NOT NULL,
+    input_resource_id INTEGER REFERENCES resources (id),
+    output_resource_id INTEGER REFERENCES resources (id),
+    input_per_tick INTEGER NOT NULL DEFAULT 0,
+    output_per_tick INTEGER NOT NULL DEFAULT 0
+);

--- a/sql/tables/resource_rules.sql
+++ b/sql/tables/resource_rules.sql
@@ -1,0 +1,6 @@
+-- Growth and decay rules for resources
+CREATE TABLE IF NOT EXISTS resource_rules (
+    resource_id INTEGER PRIMARY KEY REFERENCES resources (id) ON DELETE CASCADE,
+    growth_rate INTEGER NOT NULL DEFAULT 0,
+    decay_rate INTEGER NOT NULL DEFAULT 0
+);

--- a/sql/tables/resources.sql
+++ b/sql/tables/resources.sql
@@ -1,0 +1,6 @@
+-- Resources available in the world economy
+CREATE TABLE IF NOT EXISTS resources (
+    id SERIAL PRIMARY KEY,
+    name TEXT UNIQUE NOT NULL,
+    amount INTEGER NOT NULL DEFAULT 0
+);

--- a/sql/tables/terrain.sql
+++ b/sql/tables/terrain.sql
@@ -1,0 +1,5 @@
+-- Table definition for terrain types
+CREATE TABLE IF NOT EXISTS terrain (
+    id SERIAL PRIMARY KEY,
+    name TEXT NOT NULL UNIQUE
+);

--- a/sql/tables/tiles.sql
+++ b/sql/tables/tiles.sql
@@ -1,0 +1,8 @@
+-- Grid tiles referencing terrain
+CREATE TABLE IF NOT EXISTS tiles (
+    id SERIAL PRIMARY KEY,
+    x INTEGER NOT NULL,
+    y INTEGER NOT NULL,
+    terrain_id INTEGER NOT NULL REFERENCES terrain (id),
+    UNIQUE (x, y)
+);

--- a/sql/tables/vehicle_operations.sql
+++ b/sql/tables/vehicle_operations.sql
@@ -1,7 +1,7 @@
 -- Temporary storage for vehicle revenue and costs per tick
 CREATE TABLE IF NOT EXISTS vehicle_operations (
     id SERIAL PRIMARY KEY,
-    company_id INTEGER NOT NULL,
+    company_id INTEGER NOT NULL REFERENCES companies (id),
     revenue INTEGER NOT NULL,
     cost INTEGER NOT NULL
 );

--- a/sql/tables/vehicles.sql
+++ b/sql/tables/vehicles.sql
@@ -6,5 +6,5 @@ CREATE TABLE IF NOT EXISTS vehicles (
     schedule JSONB NOT NULL DEFAULT '[]'::JSONB,
     schedule_idx INTEGER NOT NULL DEFAULT 0,
     cargo JSONB NOT NULL DEFAULT '[]'::JSONB,
-    company_id INTEGER
+    company_id INTEGER REFERENCES companies (id)
 );


### PR DESCRIPTION
## Summary
- Establish `sql/tables` as the canonical source for table definitions
- Add generator script and Makefile target to build `sql/schema.sql`
- Remove redundant schema files and document the workflow

## Testing
- `make generate-schema`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68af769860848328926b1a90d5179d2d