### PR TITLE
Add robust error handling and logging to tick script

### DIFF
--- a/scripts/run_tick.py
+++ b/scripts/run_tick.py
@@ -1,12 +1,14 @@
 """Wrapper script to advance the game tick."""
 
 import argparse
+import logging
 import os
+import sys
 
 import psycopg
 
 
-def main() -> None:
+def main() -> int:
     """Call the ``tick`` stored procedure."""
     parser = argparse.ArgumentParser(description="Advance the game tick")
     parser.add_argument(
@@ -20,11 +22,25 @@ def main() -> None:
     if not args.dsn:
         raise RuntimeError("Database DSN must be provided via --dsn or DATABASE_URL")
 
-    with psycopg.connect(args.dsn) as conn:
+    logging.basicConfig(level=logging.INFO)
+
+    conn = None
+    try:
+        conn = psycopg.connect(args.dsn)
         with conn.cursor() as cur:
             cur.execute("CALL tick()")
         conn.commit()
+        logging.info("tick() executed successfully")
+        return 0
+    except Exception:  # pragma: no cover - simple CLI logging
+        logging.exception("tick() execution failed")
+        if conn is not None:
+            conn.rollback()
+        return 1
+    finally:
+        if conn is not None:
+            conn.close()
 
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- add basic logging to `run_tick` script
- wrap stored procedure call with rollback on failure
- return non-zero exit status when tick call fails

## Testing
- `pre-commit run --files scripts/run_tick.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68af7697bedc8328af94f27db0d5cd29