### PR TITLE
Add CLI options for DSN, refresh interval, and tick step

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,13 +28,17 @@ PostgreSQL and advance the simulation.
 1. Ensure the database is populated with the required schema.
 2. Provide connection parameters using the standard `PGHOST`, `PGPORT`,
    `PGDATABASE`, `PGUSER` and `PGPASSWORD` environment variables **or** create a
-   JSON configuration file and reference it with `PGTTD_CONFIG`.
+   JSON configuration file and reference it with `PGTTD_CONFIG`. A PostgreSQL
+   DSN may also be supplied via the `--dsn` option (overriding any environment
+   variables).
 3. Run the viewer:
 
    ```bash
-   python renderer/cli_viewer.py
+   python renderer/cli_viewer.py [--dsn DSN] [--refresh SECONDS] [--step]
    ```
 
-Press `q` to quit. Each refresh calls `tick()` in the database to advance the
-world state.
+Press `q` to quit. By default each refresh (every 0.5 seconds) calls `tick()` in
+the database to advance the world state. When `--step` is supplied the simulation
+advances only when `t` is pressed. The `--refresh` option controls the delay
+between screen updates.
 


### PR DESCRIPTION
## Summary
- allow providing DSN connection string, refresh interval and optional tick stepping via command line flags
- favor CLI options over environment configuration
- document new CLI flags and behavior in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af7696b0cc8328b1890cc1ede52a2f