### PR TITLE
Use array-based pathfinding with terrain checks

### DIFF
--- a/sql/procs/pathfinding.sql
+++ b/sql/procs/pathfinding.sql
@@ -2,89 +2,110 @@
 -- Implements a simple A* search over a grid using Manhattan distance.
 
 CREATE OR REPLACE FUNCTION find_route(
-    start_x integer, start_y integer,
-    end_x integer, end_y integer
+    start_x integer,
+    start_y integer,
+    end_x integer,
+    end_y integer,
+    cost_map integer[][] DEFAULT NULL  -- optional costs: [x, y, cost]
 )
-RETURNS integer [] [] AS $$
+RETURNS integer[][] AS $$
 DECLARE
     cur_x integer;
     cur_y integer;
     cur_cost integer;
     nbr RECORD;
+    node integer[];
     path integer[][] := ARRAY[]::integer[][];
+    open_set integer[][] := ARRAY[]::integer[][];  -- [x,y,cost,priority]
+    came_from integer[][] := ARRAY[]::integer[][]; -- [x,y,prev_x,prev_y,cost]
+    idx integer;
+    pri integer;
+    step_cost integer;
+    terrain_type text;
 BEGIN
-    -- Ensure we can run multiple times in a session
-    DROP TABLE IF EXISTS open_set;
-    DROP TABLE IF EXISTS came_from;
-
-    -- Nodes to be explored, ordered by estimated total cost
-    CREATE TEMP TABLE open_set(
-        x      integer,
-        y      integer,
-        cost   integer,
-        pri    integer
-    ) ON COMMIT DROP;
-
-    -- Tracks how we reached each explored node
-    CREATE TEMP TABLE came_from(
-        x       integer,
-        y       integer,
-        prev_x  integer,
-        prev_y  integer,
-        cost    integer,
-        PRIMARY KEY (x, y)
-    ) ON COMMIT DROP;
-
-    INSERT INTO open_set VALUES
-        (start_x, start_y, 0, abs(start_x - end_x) + abs(start_y - end_y));
-    INSERT INTO came_from VALUES (start_x, start_y, NULL, NULL, 0);
+    -- Seed initial node
+    open_set := ARRAY[[start_x, start_y, 0,
+                       abs(start_x - end_x) + abs(start_y - end_y)]];
+    came_from := ARRAY[[start_x, start_y, NULL::integer, NULL::integer, 0]];
 
     LOOP
-        SELECT x, y, cost INTO cur_x, cur_y, cur_cost
-        FROM open_set
-        ORDER BY pri
-        LIMIT 1;
-
-        -- No path found
-        IF NOT FOUND THEN
+        -- No nodes left to explore
+        IF array_length(open_set, 1) IS NULL THEN
             RETURN ARRAY[]::integer[][];
         END IF;
 
-        DELETE FROM open_set WHERE x = cur_x AND y = cur_y;
+        -- Find node with lowest priority
+        idx := 1;
+        pri := open_set[1][4];
+        FOR i IN 2..array_length(open_set, 1) LOOP
+            IF open_set[i][4] < pri THEN
+                pri := open_set[i][4];
+                idx := i;
+            END IF;
+        END LOOP;
 
+        node := open_set[idx];
+        cur_x := node[1];
+        cur_y := node[2];
+        cur_cost := node[3];
+
+        -- Remove current node from open set
+        open_set := ARRAY(
+            SELECT elem FROM unnest(open_set) WITH ORDINALITY AS u(elem, ord)
+            WHERE ord <> idx
+        );
+
+        -- Goal reached
         EXIT WHEN cur_x = end_x AND cur_y = end_y;
 
-        -- Explore four neighbouring tiles
+        -- Explore neighbouring tiles
         FOR nbr IN
             SELECT cur_x + 1 AS x, cur_y AS y
             UNION ALL SELECT cur_x - 1, cur_y
             UNION ALL SELECT cur_x, cur_y + 1
             UNION ALL SELECT cur_x, cur_y - 1
         LOOP
-            IF NOT EXISTS (SELECT 1 FROM came_from
-                           WHERE x = nbr.x AND y = nbr.y) THEN
-                INSERT INTO came_from(x, y, prev_x, prev_y, cost)
-                VALUES (nbr.x, nbr.y, cur_x, cur_y, cur_cost + 1);
-                INSERT INTO open_set(x, y, cost, pri)
-                VALUES (
-                    nbr.x, nbr.y, cur_cost + 1,
-                    cur_cost + 1
-                    + abs(nbr.x - end_x) + abs(nbr.y - end_y)
-                );
+            -- Skip impassable terrain (e.g. water or mountain)
+            SELECT type INTO terrain_type
+            FROM terrain
+            WHERE tile_x = nbr.x AND tile_y = nbr.y;
+            IF terrain_type IS NULL OR terrain_type IN ('water', 'mountain') THEN
+                CONTINUE;
+            END IF;
+
+            -- Determine traversal cost for this tile
+            step_cost := 1;
+            IF cost_map IS NOT NULL THEN
+                SELECT c[3] INTO step_cost
+                FROM unnest(cost_map) AS c
+                WHERE c[1] = nbr.x AND c[2] = nbr.y;
+                step_cost := COALESCE(step_cost, 1);
+            END IF;
+
+            IF NOT EXISTS (
+                SELECT 1 FROM unnest(came_from) AS cf
+                WHERE cf[1] = nbr.x AND cf[2] = nbr.y
+            ) THEN
+                came_from := came_from ||
+                    ARRAY[[nbr.x, nbr.y, cur_x, cur_y, cur_cost + step_cost]];
+                open_set := open_set ||
+                    ARRAY[[nbr.x, nbr.y, cur_cost + step_cost,
+                           cur_cost + step_cost +
+                           abs(nbr.x - end_x) + abs(nbr.y - end_y)]];
             END IF;
         END LOOP;
     END LOOP;
 
-    -- Reconstruct path from end to start
+    -- Reconstruct path
     cur_x := end_x;
     cur_y := end_y;
     LOOP
         path := ARRAY[[cur_x, cur_y]] || path;
         EXIT WHEN cur_x = start_x AND cur_y = start_y;
-        SELECT prev_x, prev_y INTO cur_x, cur_y
-        FROM came_from WHERE x = cur_x AND y = cur_y;
-        -- Safety: no path recorded
-        IF NOT FOUND THEN
+        SELECT cf[3], cf[4] INTO cur_x, cur_y
+        FROM unnest(came_from) AS cf
+        WHERE cf[1] = cur_x AND cf[2] = cur_y;
+        IF cur_x IS NULL THEN
             RETURN ARRAY[]::integer[][];
         END IF;
     END LOOP;
@@ -92,3 +113,4 @@ BEGIN
     RETURN path;
 END;
 $$ LANGUAGE plpgsql;
+

--- a/sql/tests/pathfinding.sql
+++ b/sql/tests/pathfinding.sql
@@ -2,18 +2,42 @@
 
 BEGIN;
 
+-- Minimal terrain setup for pathfinding tests
+CREATE TEMP TABLE terrain(
+    tile_x int,
+    tile_y int,
+    type text
+);
+INSERT INTO terrain(tile_x, tile_y, type)
+SELECT x, y, 'plain'
+FROM generate_series(1,3) x CROSS JOIN generate_series(1,3) y;
+-- Mark a water tile to ensure impassable terrain is skipped
+UPDATE terrain SET type = 'water' WHERE tile_x = 2 AND tile_y = 1;
+
 -- load function under test
 \ir ../procs/pathfinding.sql
 
--- verify simple route
+-- verify simple route around impassable water tile
 DO $$
 DECLARE
     res integer[][];
-    expected integer[][] := ARRAY[[1,1],[2,1],[3,1],[3,2]];
+    expected integer[][] := ARRAY[[1,1],[1,2],[2,2],[3,2]];
 BEGIN
     res := find_route(1,1,3,2);
     IF res IS NULL OR res != expected THEN
         RAISE EXCEPTION 'route mismatch: %', res;
+    END IF;
+END$$;
+
+-- verify optional cost map parameter is accepted
+DO $$
+DECLARE
+    res integer[][];
+    expected integer[][] := ARRAY[[1,1],[1,2],[2,2],[3,2]];
+BEGIN
+    res := find_route(1,1,3,2, ARRAY[[1,2,5]]);
+    IF res IS NULL OR res != expected THEN
+        RAISE EXCEPTION 'weighted route mismatch: %', res;
     END IF;
 END$$;
 
@@ -30,3 +54,4 @@ BEGIN
 END$$;
 
 ROLLBACK;
+


### PR DESCRIPTION
## Summary
- Replace temporary tables with array-driven A* pathfinding and optional per-tile costs
- Skip impassable terrain like water or mountains when exploring neighbours
- Expand pathfinding tests with terrain setup and cost-map coverage

## Testing
- `psql -v ON_ERROR_STOP=1 -f sql/tests/pathfinding.sql` *(fails: connection to server on socket "/var/run/postgresql/.s.PGSQL.5432" failed: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68af7694f6a483289fca464cad41618d