### PR TITLE
Add SQL tests for vehicle movement and tick updates

### DIFF
--- a/sql/tests.sql
+++ b/sql/tests.sql
@@ -1,0 +1,6 @@
+\set ON_ERROR_STOP on
+
+\ir tests/pathfinding.sql
+\ir tests/economy_tick.sql
+\ir tests/move_vehicles.sql
+\ir tests/tick.sql

--- a/sql/tests/move_vehicles.sql
+++ b/sql/tests/move_vehicles.sql
@@ -1,0 +1,40 @@
+\set ON_ERROR_STOP on
+
+BEGIN;
+
+-- load schema and procedure definitions
+\ir ../tables/vehicles.sql
+\ir ../procs/move_vehicles.sql
+
+-- setup initial data
+TRUNCATE vehicles RESTART IDENTITY;
+INSERT INTO vehicles (x, y, schedule)
+VALUES (0, 0, '[{"x":0,"y":0},{"x":1,"y":0}]');
+
+-- first move should advance schedule without moving
+CALL move_vehicles();
+DO $$
+BEGIN
+    IF (SELECT schedule_idx FROM vehicles WHERE id = 1) != 1 THEN
+        RAISE EXCEPTION 'schedule did not advance';
+    END IF;
+    IF (SELECT x FROM vehicles WHERE id = 1) != 0 OR
+       (SELECT y FROM vehicles WHERE id = 1) != 0 THEN
+        RAISE EXCEPTION 'vehicle moved unexpectedly';
+    END IF;
+END$$;
+
+-- second move should move toward next waypoint
+CALL move_vehicles();
+DO $$
+BEGIN
+    IF (SELECT x FROM vehicles WHERE id = 1) != 1 OR
+       (SELECT y FROM vehicles WHERE id = 1) != 0 THEN
+        RAISE EXCEPTION 'vehicle did not reach expected coordinates';
+    END IF;
+    IF (SELECT schedule_idx FROM vehicles WHERE id = 1) != 1 THEN
+        RAISE EXCEPTION 'schedule index incorrect after movement';
+    END IF;
+END$$;
+
+ROLLBACK;

--- a/sql/tests/tick.sql
+++ b/sql/tests/tick.sql
@@ -1,0 +1,29 @@
+\set ON_ERROR_STOP on
+
+BEGIN;
+
+-- load procedure under test
+\ir ../procs/tick.sql
+
+-- setup game state and terrain
+CREATE TABLE game_state (current_tick INT);
+INSERT INTO game_state (current_tick) VALUES (0);
+CREATE TABLE terrain (id SERIAL PRIMARY KEY, updated_tick INT);
+INSERT INTO terrain DEFAULT VALUES;
+INSERT INTO terrain DEFAULT VALUES;
+
+-- execute tick
+CALL tick();
+
+-- verify tick counter and terrain updates
+DO $$
+BEGIN
+    IF (SELECT current_tick FROM game_state) != 1 THEN
+        RAISE EXCEPTION 'tick counter not incremented';
+    END IF;
+    IF EXISTS (SELECT 1 FROM terrain WHERE updated_tick <> 1) THEN
+        RAISE EXCEPTION 'terrain not updated with tick';
+    END IF;
+END$$;
+
+ROLLBACK;


### PR DESCRIPTION
## Summary
- add psql test for vehicle movement to ensure schedule indices and coordinates update correctly
- add psql test verifying tick counter and terrain update
- wire new tests into sql test runner

## Testing
- `sudo -u postgres psql -f sql/tests.sql`

------
https://chatgpt.com/codex/tasks/task_e_68af7695480c83289abd35bc4020178b