### PR TITLE
Ensure companies table exists for vehicle SQL tests

### DIFF
--- a/sql/tests/vehicles.sql
+++ b/sql/tests/vehicles.sql
@@ -2,7 +2,8 @@
 
 BEGIN;
 
--- load table definition
+-- load table definitions
+\ir ../tables/companies.sql
 \ir ../tables/vehicles.sql
 
 -- negative position should fail


### PR DESCRIPTION
## Summary
- include companies table definition before vehicles table in vehicle tests to satisfy foreign key

## Testing
- `pre-commit run --files sql/tests/vehicles.sql`
- `sudo -u postgres psql -v ON_ERROR_STOP=1 -f sql/tests/vehicles.sql postgres`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68af79a56e508328924eb3c12ddd0ad3