### PR TITLE
Expand Postgres test coverage

### DIFF
--- a/sql/tests.sql
+++ b/sql/tests.sql
@@ -4,3 +4,6 @@
 \ir tests/economy_tick.sql
 \ir tests/move_vehicles.sql
 \ir tests/tick.sql
+\ir tests/vehicles.sql
+\ir tests/vehicle_movement.sql
+\ir tests/update_balances.sql

--- a/sql/tests/update_balances.sql
+++ b/sql/tests/update_balances.sql
@@ -1,0 +1,35 @@
+\set ON_ERROR_STOP on
+
+BEGIN;
+
+-- load table definitions and function under test
+\ir ../tables/companies.sql
+\ir ../tables/industry_outputs.sql
+\ir ../tables/vehicle_operations.sql
+\ir ../procs/update_balances.sql
+
+-- setup initial data
+INSERT INTO companies (name, cash, income, expenses)
+VALUES ('Acme', 100, 10, 20);
+INSERT INTO industry_outputs (company_id, value) VALUES (1, 50);
+INSERT INTO vehicle_operations (company_id, revenue, cost)
+VALUES (1, 30, 10);
+
+-- execute function
+SELECT update_balances();
+
+-- verify results
+DO $$
+BEGIN
+    IF (SELECT cash FROM companies WHERE id = 1) <> 170 THEN
+        RAISE EXCEPTION 'cash mismatch';
+    END IF;
+    IF (SELECT income FROM companies WHERE id = 1) <> 80 THEN
+        RAISE EXCEPTION 'income mismatch';
+    END IF;
+    IF (SELECT expenses FROM companies WHERE id = 1) <> 10 THEN
+        RAISE EXCEPTION 'expenses mismatch';
+    END IF;
+END$$;
+
+ROLLBACK;


### PR DESCRIPTION
## Summary
- add SQL test verifying `update_balances` updates company cash, income and expenses
- include vehicle and balance tests in `sql/tests.sql` to widen coverage

## Testing
- `pre-commit run --files sql/tests.sql sql/tests/update_balances.sql`
- `pytest`
- `psql -v ON_ERROR_STOP=1 -d postgres -f sql/tests.sql` *(fails: malformed array literal in pathfinding test)*
- `psql -v ON_ERROR_STOP=1 -f sql/tests/update_balances.sql`

------
https://chatgpt.com/codex/tasks/task_e_68af7a8c12a883288dea75d34b31cf5a