### PR TITLE
Handle connection errors in run_tick script

### DIFF
--- a/scripts/run_tick.py
+++ b/scripts/run_tick.py
@@ -2,8 +2,9 @@
 
 import argparse
 import logging
-import os
 import sys
+
+import psycopg
 
 import db_util
 
@@ -13,19 +14,21 @@ def main() -> int:
     parser = argparse.ArgumentParser(description="Advance the game tick")
     args = db_util.parse_dsn(parser)
 
-    with db_util.connect(args.dsn) as conn:
-        with conn.cursor() as cur:
-            cur.execute("CALL tick()")
-        conn.commit()
-        logging.info("tick() executed successfully")
-        return 0
+    conn: psycopg.Connection | None = None
+    try:
+        with db_util.connect(args.dsn) as conn:
+            with conn.cursor() as cur:
+                cur.execute("CALL tick()")
+            conn.commit()
+            logging.info("tick() executed successfully")
+            return 0
     except Exception:  # pragma: no cover - simple CLI logging
         logging.exception("tick() execution failed")
-        if conn is not None:
+        if conn:
             conn.rollback()
         return 1
     finally:
-        if conn is not None:
+        if conn:
             conn.close()
 
 

--- a/tests/test_run_tick.py
+++ b/tests/test_run_tick.py
@@ -1,0 +1,33 @@
+import contextlib
+import importlib.util
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest import mock
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "scripts"))
+spec = importlib.util.spec_from_file_location(
+    "run_tick", Path(__file__).resolve().parents[1] / "scripts" / "run_tick.py"
+)
+run_tick = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(run_tick)
+
+
+def test_main_rolls_back_on_failure(monkeypatch):
+    conn = mock.MagicMock()
+    cur = mock.MagicMock()
+    conn.cursor.return_value.__enter__.return_value = cur
+    cur.execute.side_effect = RuntimeError
+
+    monkeypatch.setattr(
+        run_tick.db_util, "connect", lambda dsn: contextlib.nullcontext(conn)
+    )
+    monkeypatch.setattr(
+        run_tick.db_util, "parse_dsn", lambda parser: SimpleNamespace(dsn="dsn")
+    )
+
+    result = run_tick.main()
+
+    assert result == 1
+    conn.rollback.assert_called_once()
+    conn.close.assert_called_once()


### PR DESCRIPTION
## Summary
- guard tick call with try/except/finally and rollback on failure
- add regression test for run_tick

## Testing
- black scripts/run_tick.py tests/test_run_tick.py
- flake8 scripts/run_tick.py tests/test_run_tick.py (fails: command not found)
- pytest -q


------
https://chatgpt.com/codex/tasks/task_e_68af7ffbaa5c832898ec9ce074a72ac4