### PR TITLE
refactor cli viewer args

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,8 +55,10 @@ PostgreSQL and advance the simulation.
    python renderer/cli_viewer.py [--dsn DSN] [--refresh SECONDS] [--step]
    ```
 
-Press `q` to quit. By default each refresh (every 0.5 seconds) calls `tick()` in
-the database to advance the world state. When `--step` is supplied the simulation
-advances only when `t` is pressed. The `--refresh` option controls the delay
-between screen updates.
+   * `--refresh` – delay between screen updates in seconds (default: 0.5)
+   * `--step` – advance the simulation only when `t` is pressed
+
+Press `q` to quit. By default each refresh calls `tick()` in the database to
+advance the world state. When `--step` is supplied the simulation advances only
+when `t` is pressed.
 

--- a/renderer/cli_viewer.py
+++ b/renderer/cli_viewer.py
@@ -131,7 +131,10 @@ def render(stdscr, tiles: Iterable[Tile]) -> None:
 # Entry point
 # ---------------------------------------------------------------------------
 
-def main(stdscr, dsn: str | None = None) -> None:
+
+def main(stdscr, dsn: str | None, refresh: float, step: bool) -> None:
+    """Render the simulation in a curses window."""
+
     curses.curs_set(0)
     stdscr.nodelay(True)
     if dsn:
@@ -146,21 +149,33 @@ def main(stdscr, dsn: str | None = None) -> None:
             ch = stdscr.getch()
             if ch == ord("q"):
                 break
-            if args.step:
+            if step:
                 if ch == ord("t"):
                     advance_tick(conn)
             else:
                 advance_tick(conn)
-            time.sleep(args.refresh)
+            time.sleep(refresh)
     finally:
         conn.close()
 
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--refresh",
+        type=float,
+        default=0.5,
+        help="delay between screen updates in seconds",
+    )
+    parser.add_argument(
+        "--step",
+        action="store_true",
+        help="advance simulation only when 't' is pressed",
+    )
     try:
         args = db_util.parse_dsn(parser)
         dsn = args.dsn
     except RuntimeError:
+        args = parser.parse_args()
         dsn = None
-    curses.wrapper(main, dsn)
+    curses.wrapper(main, dsn, args.refresh, args.step)


### PR DESCRIPTION
## Summary
- pass refresh delay and step mode into cli viewer main
- document available CLI flags

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af7ffb10d88328987dcf00bf0f5667