### PR TITLE
Add tests for CLI scripts and fix run_tick handling

### DIFF
--- a/scripts/run_tick.py
+++ b/scripts/run_tick.py
@@ -2,7 +2,6 @@
 
 import argparse
 import logging
-import os
 import sys
 
 import db_util
@@ -13,7 +12,9 @@ def main() -> int:
     parser = argparse.ArgumentParser(description="Advance the game tick")
     args = db_util.parse_dsn(parser)
 
-    with db_util.connect(args.dsn) as conn:
+    conn = None
+    try:
+        conn = db_util.connect(args.dsn)
         with conn.cursor() as cur:
             cur.execute("CALL tick()")
         conn.commit()
@@ -31,3 +32,4 @@ def main() -> int:
 
 if __name__ == "__main__":
     sys.exit(main())
+

--- a/tests/test_create_vehicle.py
+++ b/tests/test_create_vehicle.py
@@ -1,0 +1,111 @@
+import sys
+from pathlib import Path
+import json
+from unittest.mock import MagicMock
+
+import pytest
+
+# Ensure scripts directory is on the path
+sys.path.append(str(Path(__file__).resolve().parents[1] / "scripts"))
+
+import create_vehicle  # type: ignore
+import db_util  # type: ignore
+
+
+class DummyCursor:
+    def __init__(self):
+        self.executed = None
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        pass
+
+    def execute(self, sql, params):
+        self.executed = (sql, params)
+
+
+class DummyConnection:
+    def __init__(self, cursor: DummyCursor):
+        self.cursor_obj = cursor
+        self.committed = False
+        self.closed = False
+
+    def cursor(self):
+        return self.cursor_obj
+
+    def commit(self):
+        self.committed = True
+
+    def close(self):
+        self.closed = True
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        self.close()
+
+
+DSN = "postgresql://example"
+
+
+def test_main_success(monkeypatch, capsys):
+    cursor = DummyCursor()
+    conn = DummyConnection(cursor)
+
+    def fake_connect(dsn: str):
+        assert dsn == DSN
+        return conn
+
+    monkeypatch.setattr(db_util, "connect", fake_connect)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "create_vehicle.py",
+            "--dsn",
+            DSN,
+            "--x",
+            "1",
+            "--y",
+            "2",
+            "--schedule",
+            "[{\"x\":1,\"y\":2}]",
+            "--cargo",
+            "[{\"resource\":\"wood\",\"amount\":3}]",
+            "--company-id",
+            "7",
+        ],
+    )
+
+    create_vehicle.main()
+
+    sql, params = cursor.executed
+    assert "INSERT INTO vehicles" in sql
+    assert params == (
+        1,
+        2,
+        json.dumps([{"x": 1, "y": 2}]),
+        json.dumps([{"resource": "wood", "amount": 3}]),
+        7,
+    )
+    assert conn.committed
+    assert conn.closed
+    assert f"Inserted vehicle at 1 2" in capsys.readouterr().out
+
+
+def test_invalid_schedule_json(monkeypatch):
+    connect_mock = MagicMock()
+    monkeypatch.setattr(db_util, "connect", connect_mock)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["create_vehicle.py", "--dsn", DSN, "--schedule", "not json"],
+    )
+
+    with pytest.raises(ValueError, match="Invalid JSON for --schedule"):
+        create_vehicle.main()
+
+    connect_mock.assert_not_called()

--- a/tests/test_run_tick.py
+++ b/tests/test_run_tick.py
@@ -1,0 +1,84 @@
+import sys
+from pathlib import Path
+import pytest
+
+# Ensure scripts directory is on the path
+sys.path.append(str(Path(__file__).resolve().parents[1] / "scripts"))
+
+import run_tick  # type: ignore
+import db_util  # type: ignore
+
+
+class DummyCursor:
+    def __init__(self, should_fail: bool = False):
+        self.should_fail = should_fail
+        self.sql = None
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        pass
+
+    def execute(self, sql: str):
+        if self.should_fail:
+            raise Exception("boom")
+        self.sql = sql
+
+
+class DummyConnection:
+    def __init__(self, cursor: DummyCursor):
+        self.cursor_obj = cursor
+        self.committed = False
+        self.rolled_back = False
+        self.closed = False
+
+    def cursor(self):
+        return self.cursor_obj
+
+    def commit(self):
+        self.committed = True
+
+    def rollback(self):
+        self.rolled_back = True
+
+    def close(self):
+        self.closed = True
+
+
+DSN = "postgresql://example"
+
+
+def test_main_success(monkeypatch):
+    cursor = DummyCursor()
+    conn = DummyConnection(cursor)
+
+    def fake_connect(dsn: str):
+        assert dsn == DSN
+        return conn
+
+    monkeypatch.setattr(db_util, "connect", fake_connect)
+    monkeypatch.setattr(sys, "argv", ["run_tick.py", "--dsn", DSN])
+
+    rc = run_tick.main()
+
+    assert rc == 0
+    assert cursor.sql == "CALL tick()"
+    assert conn.committed
+    assert conn.closed
+    assert not conn.rolled_back
+
+
+def test_main_failure(monkeypatch):
+    cursor = DummyCursor(should_fail=True)
+    conn = DummyConnection(cursor)
+
+    monkeypatch.setattr(db_util, "connect", lambda dsn: conn)
+    monkeypatch.setattr(sys, "argv", ["run_tick.py", "--dsn", DSN])
+
+    rc = run_tick.main()
+
+    assert rc == 1
+    assert conn.rolled_back
+    assert conn.closed
+    assert not conn.committed


### PR DESCRIPTION
## Summary
- fix run_tick connection handling
- add tests for run_tick and create_vehicle scripts

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af7ff8b61483288931fbd9514e63d7