### PR TITLE
Handle context manager connections in run_tick

### DIFF
--- a/scripts/run_tick.py
+++ b/scripts/run_tick.py
@@ -15,8 +15,13 @@ def main() -> int:
     args = db_util.parse_dsn(parser)
 
     conn = None
+    conn_ctx = None
     try:
-        conn = db_util.connect(args.dsn)
+        conn_ctx = db_util.connect(args.dsn)
+        if hasattr(conn_ctx, "__enter__"):
+            conn = conn_ctx.__enter__()
+        else:
+            conn = conn_ctx
         with conn.cursor() as cur:
             cur.execute("CALL tick()")
         conn.commit()
@@ -30,6 +35,8 @@ def main() -> int:
     finally:
         if conn:
             conn.close()
+        if conn_ctx is not conn and hasattr(conn_ctx, "__exit__"):
+            conn_ctx.__exit__(None, None, None)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Allow `run_tick.main` to work with connections returned as context managers
- Ensure rollback and close are still invoked when failures occur

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68af82f32ea08328b0b1c45e142042bd