### PR TITLE
Gracefully exit on validation errors in vehicle creation script

### DIFF
--- a/tests/test_create_vehicle.py
+++ b/tests/test_create_vehicle.py
@@ -72,9 +72,9 @@ def test_main_success(monkeypatch, capsys):
             "--y",
             "2",
             "--schedule",
-            "[{\"x\":1,\"y\":2}]",
+            '[{"x":1,"y":2}]',
             "--cargo",
-            "[{\"resource\":\"wood\",\"amount\":3}]",
+            '[{"resource":"wood","amount":3}]',
             "--company-id",
             "7",
         ],
@@ -96,7 +96,7 @@ def test_main_success(monkeypatch, capsys):
     assert f"Inserted vehicle at 1 2" in capsys.readouterr().out
 
 
-def test_invalid_schedule_json(monkeypatch):
+def test_invalid_schedule_json(monkeypatch, capsys):
     connect_mock = MagicMock()
     monkeypatch.setattr(db_util, "connect", connect_mock)
     monkeypatch.setattr(
@@ -105,7 +105,9 @@ def test_invalid_schedule_json(monkeypatch):
         ["create_vehicle.py", "--dsn", DSN, "--schedule", "not json"],
     )
 
-    with pytest.raises(ValueError, match="Invalid JSON for --schedule"):
+    with pytest.raises(SystemExit) as exc:
         create_vehicle.main()
+    assert exc.value.code == 1
+    assert "Invalid JSON for --schedule" in capsys.readouterr().err
 
     connect_mock.assert_not_called()


### PR DESCRIPTION
## Summary
- wrap `create_vehicle.main` logic in `try`/`except` to emit validation errors to stderr and exit 1
- add regression test ensuring invalid JSON aborts before calling `db_util.connect`

## Testing
- `pre-commit run --files scripts/create_vehicle.py tests/test_create_vehicle.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68af861058488328b5893431ff7968cc