### PR TITLE
Use context-managed connections in tick runner

### DIFF
--- a/scripts/run_tick.py
+++ b/scripts/run_tick.py
@@ -4,8 +4,6 @@ import argparse
 import logging
 import sys
 
-import psycopg
-
 import db_util
 
 
@@ -14,29 +12,21 @@ def main() -> int:
     parser = argparse.ArgumentParser(description="Advance the game tick")
     args = db_util.parse_dsn(parser)
 
-    conn = None
-    conn_ctx = None
     try:
-        conn_ctx = db_util.connect(args.dsn)
-        if hasattr(conn_ctx, "__enter__"):
-            conn = conn_ctx.__enter__()
-        else:
-            conn = conn_ctx
-        with conn.cursor() as cur:
-            cur.execute("CALL tick()")
-        conn.commit()
-        logging.info("tick() executed successfully")
-        return 0
+        with db_util.connect(args.dsn) as conn:
+            try:
+                with conn.cursor() as cur:
+                    cur.execute("CALL tick()")
+                conn.commit()
+            except Exception:  # pragma: no cover - simple CLI logging
+                logging.exception("tick() execution failed")
+                conn.rollback()
+                return 1
     except Exception:  # pragma: no cover - simple CLI logging
         logging.exception("tick() execution failed")
-        if conn:
-            conn.rollback()
         return 1
-    finally:
-        if conn:
-            conn.close()
-        if conn_ctx is not conn and hasattr(conn_ctx, "__exit__"):
-            conn_ctx.__exit__(None, None, None)
+    logging.info("tick() executed successfully")
+    return 0
 
 
 if __name__ == "__main__":

--- a/tests/test_run_tick.py
+++ b/tests/test_run_tick.py
@@ -43,6 +43,12 @@ class DummyConnection:
         self.rolled_back = False
         self.closed = False
 
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        self.close()
+
     def cursor(self):
         return self.cursor_obj
 
@@ -95,7 +101,7 @@ def test_main_rolls_back_on_failure(monkeypatch):
     cur.execute.side_effect = RuntimeError
 
     monkeypatch.setattr(
-        run_tick.db_util, "connect", lambda dsn: contextlib.nullcontext(conn)
+        run_tick.db_util, "connect", lambda dsn: contextlib.closing(conn)
     )
     monkeypatch.setattr(
         run_tick.db_util, "parse_dsn", lambda parser: SimpleNamespace(dsn="dsn")


### PR DESCRIPTION
## Summary
- simplify `run_tick.py` by relying on `db_util.connect` as a context manager
- add error handling that logs, rolls back and returns proper exit codes
- adjust tests to use context-managed connections

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af860da98483289d42080aec8c1dcc