### PR TITLE
Handle NULL schedule_idx when moving vehicles

### DIFF
--- a/sql/procs/move_vehicles.sql
+++ b/sql/procs/move_vehicles.sql
@@ -12,7 +12,9 @@ BEGIN
             jsonb_array_length(schedule) AS sched_len,
             CASE
                 WHEN jsonb_array_length(schedule) = 0 THEN NULL
-                WHEN schedule_idx >= jsonb_array_length(schedule) OR schedule_idx < 0 THEN 0
+                WHEN schedule_idx IS NULL
+                     OR schedule_idx >= jsonb_array_length(schedule)
+                     OR schedule_idx < 0 THEN 0
                 ELSE schedule_idx
             END AS idx
         FROM vehicles

--- a/sql/tests.sql
+++ b/sql/tests.sql
@@ -3,6 +3,7 @@
 \ir tests/pathfinding.sql
 \ir tests/economy_tick.sql
 \ir tests/move_vehicles.sql
+\ir tests/move_vehicles_null_schedule_idx.sql
 \ir tests/tick.sql
 \ir tests/vehicles.sql
 \ir tests/vehicle_movement.sql

--- a/sql/tests/move_vehicles_null_schedule_idx.sql
+++ b/sql/tests/move_vehicles_null_schedule_idx.sql
@@ -1,0 +1,44 @@
+\set ON_ERROR_STOP on
+
+BEGIN;
+
+-- load schema and procedure definitions
+\ir ../tables/companies.sql
+\ir ../tables/vehicles.sql
+\ir ../procs/move_vehicles.sql
+
+-- allow NULL schedule_idx for testing
+ALTER TABLE vehicles ALTER COLUMN schedule_idx DROP NOT NULL;
+
+-- setup initial data
+TRUNCATE vehicles RESTART IDENTITY;
+INSERT INTO vehicles (x, y, schedule, schedule_idx)
+VALUES (0, 0, '[{"x":0,"y":0},{"x":1,"y":0}]', NULL);
+
+-- first move should reset schedule_idx and not move
+CALL move_vehicles();
+DO $$
+BEGIN
+    IF (SELECT schedule_idx FROM vehicles WHERE id = 1) != 1 THEN
+        RAISE EXCEPTION 'schedule index not reset to 1';
+    END IF;
+    IF (SELECT x FROM vehicles WHERE id = 1) != 0 OR
+       (SELECT y FROM vehicles WHERE id = 1) != 0 THEN
+        RAISE EXCEPTION 'vehicle moved unexpectedly';
+    END IF;
+END$$;
+
+-- second move should move toward next waypoint
+CALL move_vehicles();
+DO $$
+BEGIN
+    IF (SELECT x FROM vehicles WHERE id = 1) != 1 OR
+       (SELECT y FROM vehicles WHERE id = 1) != 0 THEN
+        RAISE EXCEPTION 'vehicle did not move toward waypoint';
+    END IF;
+    IF (SELECT schedule_idx FROM vehicles WHERE id = 1) != 1 THEN
+        RAISE EXCEPTION 'schedule index incorrect after movement';
+    END IF;
+END$$;
+
+ROLLBACK;


### PR DESCRIPTION
## Summary
- reset vehicle schedule index when it is NULL or out-of-range
- add regression test for vehicles with NULL schedule_idx

## Testing
- `pre-commit run --files sql/procs/move_vehicles.sql sql/tests/move_vehicles_null_schedule_idx.sql sql/tests.sql`
- `sudo -u postgres psql -v ON_ERROR_STOP=1 -f sql/tests.sql`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68af8611a5848328a551acd822269541