### PR TITLE
Refactor tick runner to central module

### DIFF
--- a/pgttd/run_tick.py
+++ b/pgttd/run_tick.py
@@ -3,6 +3,7 @@
 import argparse
 import logging
 import sys
+from contextlib import ExitStack
 
 from . import db
 
@@ -12,29 +13,20 @@ def main() -> int:
     parser = argparse.ArgumentParser(description="Advance the game tick")
     args = db.parse_dsn(parser)
 
-    conn = None
-    conn_ctx = None
-    try:
+    with ExitStack() as stack:
         conn_ctx = db.connect(args.dsn)
-        if hasattr(conn_ctx, "__enter__"):
-            conn = conn_ctx.__enter__()
-        else:
-            conn = conn_ctx
-        with conn.cursor() as cur:
-            cur.execute("CALL tick()")
-        conn.commit()
-        logging.info("tick() executed successfully")
-        return 0
-    except Exception:  # pragma: no cover - simple CLI logging
-        logging.exception("tick() execution failed")
-        if conn:
+        conn = stack.enter_context(conn_ctx) if hasattr(conn_ctx, "__enter__") else conn_ctx
+        stack.callback(getattr(conn, "close", lambda: None))
+        try:
+            with conn.cursor() as cur:
+                cur.execute("CALL tick()")
+            conn.commit()
+            logging.info("tick() executed successfully")
+            return 0
+        except Exception:  # pragma: no cover - simple CLI logging
+            logging.exception("tick() execution failed")
             conn.rollback()
-        return 1
-    finally:
-        if conn:
-            conn.close()
-        if conn_ctx is not conn and hasattr(conn_ctx, "__exit__"):
-            conn_ctx.__exit__(None, None, None)
+            return 1
 
 
 if __name__ == "__main__":  # pragma: no cover - script execution

--- a/scripts/run_tick.py
+++ b/scripts/run_tick.py
@@ -1,45 +1,9 @@
 """Wrapper script to advance the game tick."""
 
-import argparse
-import logging
-import sys
-
-import pgttd.db as db
-
-
-def main() -> int:
-    """Call the ``tick`` stored procedure."""
-    parser = argparse.ArgumentParser(description="Advance the game tick")
-    args = db.parse_dsn(parser)
-
-    conn = None
-    try:
-        conn_ctx = db.connect(args.dsn)
-        if hasattr(conn_ctx, "__enter__"):
-            conn = conn_ctx.__enter__()
-        else:
-            conn = conn_ctx
-        with conn.cursor() as cur:
-            cur.execute("CALL tick()")
-        conn.commit()
-        logging.info("tick() executed successfully")
-        return 0
-
-    except Exception:  # pragma: no cover - simple CLI logging
-        logging.exception("tick() execution failed")
-        if conn is not None:
-            try:
-                conn.rollback()
-            except Exception:
-                pass
-        return 1
-    finally:
-        if conn is not None:
-            try:
-                conn.close()
-            except Exception:
-                pass
+from pgttd.run_tick import main
 
 
 if __name__ == "__main__":
+    import sys
     sys.exit(main())
+

--- a/tests/test_run_tick.py
+++ b/tests/test_run_tick.py
@@ -5,7 +5,7 @@ from unittest import mock
 
 import pytest
 
-from scripts import run_tick
+from pgttd import run_tick
 
 DSN = "postgresql://example"
 


### PR DESCRIPTION
## Summary
- Simplify `scripts/run_tick.py` to delegate to `pgttd.run_tick.main`
- Use `ExitStack` in `pgttd.run_tick.main` to ensure connection closure and rollback on failure
- Adjust tests for new run-tick entry point

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68af983b35bc8328abde3776acbe41d0