### PR TITLE
Stream tile rendering to reduce memory usage

### DIFF
--- a/renderer/cli_viewer.py
+++ b/renderer/cli_viewer.py
@@ -82,7 +82,7 @@ def fetch_tiles(conn) -> Iterable[Tile]:
     )
     with conn.cursor() as cur:
         cur.execute(sql)
-        for x, y, ch, color in cur.fetchall():
+        for x, y, ch, color in cur:
             yield Tile(x, y, ch, color or "white")
 
 
@@ -146,7 +146,7 @@ def main(stdscr, dsn: str | None, refresh: float, step: bool) -> None:
         conn = psycopg.connect(**config)
     try:
         while True:
-            tiles = list(fetch_tiles(conn))
+            tiles = fetch_tiles(conn)
             render(stdscr, tiles)
             ch = stdscr.getch()
             if ch == ord("q"):

--- a/scripts/postgres_coverage.py
+++ b/scripts/postgres_coverage.py
@@ -48,7 +48,7 @@ def collect_coverage(dsn: str) -> List[Tuple[str, float, float]]:
         with conn.cursor() as cur:
             cur.execute("CREATE EXTENSION IF NOT EXISTS plpgsql_check")
             cur.execute(query)
-            rows = cur.fetchall()
+            rows = list(cur)
     return [(func, float(stmt), float(branch)) for func, stmt, branch in rows]
 
 

--- a/tests/test_generate_sprites.py
+++ b/tests/test_generate_sprites.py
@@ -34,7 +34,7 @@ def test_insert_statement_is_escaped(tmp_path):
     conn.execute("CREATE TABLE sprites(name TEXT, image_base64 TEXT)")
     conn.executescript(sql)
 
-    rows = conn.execute("SELECT name, image_base64 FROM sprites").fetchall()
+    rows = list(conn.execute("SELECT name, image_base64 FROM sprites"))
     assert rows == [(malicious_name, payload)]
 
 

--- a/tests/test_renderer_memory.py
+++ b/tests/test_renderer_memory.py
@@ -1,0 +1,55 @@
+import types
+import tracemalloc
+
+from renderer.cli_viewer import render, Tile
+
+class DummyScreen:
+    def erase(self):
+        pass
+    def addch(self, y, x, ch, color):
+        pass
+    def refresh(self):
+        pass
+
+
+def test_render_uses_less_memory_with_generator(monkeypatch):
+    dummy_curses = types.SimpleNamespace(
+        COLOR_BLACK=0,
+        COLOR_RED=1,
+        COLOR_GREEN=2,
+        COLOR_YELLOW=3,
+        COLOR_BLUE=4,
+        COLOR_MAGENTA=5,
+        COLOR_CYAN=6,
+        COLOR_WHITE=7,
+        init_pair=lambda idx, fg, bg: None,
+        color_pair=lambda idx: idx,
+    )
+    monkeypatch.setattr("renderer.cli_viewer.curses", dummy_curses, raising=False)
+
+    screen = DummyScreen()
+    N = 100000
+
+    def generate_tiles(n):
+        for i in range(n):
+            yield Tile(x=i, y=0, ch="@", color="white")
+
+    def run_list():
+        tiles = list(generate_tiles(N))
+        render(screen, tiles)
+
+    def run_gen():
+        tiles = generate_tiles(N)
+        render(screen, tiles)
+
+    tracemalloc.start()
+    run_list()
+    _, peak_list = tracemalloc.get_traced_memory()
+    tracemalloc.stop()
+
+    tracemalloc.start()
+    run_gen()
+    _, peak_gen = tracemalloc.get_traced_memory()
+    tracemalloc.stop()
+
+    assert peak_gen < peak_list


### PR DESCRIPTION
## Summary
- Iterate database cursors directly in CLI viewer and coverage script
- Render tiles without materializing full result sets
- Add regression test to ensure generator-based rendering uses less memory

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af9838a4c483289574b23470695915