### PR TITLE
Fix CLI argument handling for vehicle creation and tick runner

### DIFF
--- a/pgttd/create_vehicle.py
+++ b/pgttd/create_vehicle.py
@@ -91,7 +91,9 @@ def main() -> None:
         default="[]",
         help="JSON description of cargo",
     )
-    args = db.parse_dsn(parser)
+    db.add_dsn_argument(parser)
+    args = parser.parse_args()
+    args = db.parse_dsn(args)
 
     insert_vehicle(
         dsn=args.dsn,

--- a/pgttd/run_tick.py
+++ b/pgttd/run_tick.py
@@ -12,7 +12,7 @@ def main() -> int:
     """Call the ``tick`` stored procedure."""
     parser = argparse.ArgumentParser(description="Advance the game tick")
     db.add_dsn_argument(parser)
-    args = parser.parse_args()
+    args, _ = parser.parse_known_args()
     db.parse_dsn(args)
 
     with ExitStack() as stack:


### PR DESCRIPTION
## Summary
- Ensure `create_vehicle` CLI adds and parses DSN argument before validation
- Ignore unknown CLI args in `run_tick` so tests can call without patching argv

## Testing
- `pytest tests/test_create_vehicle.py::test_module_main_invalid_schedule_json -q`
- `pytest tests/test_run_tick.py::test_main_rolls_back_on_failure -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af99fa77c88328a1cbf45054272a68