### PR TITLE
Use JSON parameter for benchmark vehicle schedule

### DIFF
--- a/scripts/benchmark_move_vehicles.py
+++ b/scripts/benchmark_move_vehicles.py
@@ -6,6 +6,7 @@ PostgreSQL database.
 """
 
 import argparse
+import json
 import time
 
 import pgttd.db as db
@@ -23,14 +24,15 @@ def main() -> None:
     args = parser.parse_args()
     db.parse_dsn(args)
 
+    schedule = [{"x": 100, "y": 0}]
+
     with db.connect(args.dsn) as conn:
         with conn.cursor() as cur:
             cur.execute("TRUNCATE vehicles")
             cur.execute(
                 "INSERT INTO vehicles (x, y, schedule) "
-                'SELECT 0, 0, \'[{"x":100,"y":0}]\'::jsonb '
-                "FROM generate_series(1,%s)",
-                (args.count,),
+                "SELECT 0, 0, %s::jsonb FROM generate_series(1, %s)",
+                (json.dumps(schedule), args.count),
             )
             conn.commit()
 


### PR DESCRIPTION
## Summary
- import json and define schedule variable in benchmark_move_vehicles script
- parameterize vehicle schedule JSON when inserting test data

## Testing
- `pre-commit run --files scripts/benchmark_move_vehicles.py`
- `pytest` *(fails: AttributeError in pgttd/db.py:19 during tests/test_create_vehicle.py::test_module_main_invalid_schedule_json)*

------
https://chatgpt.com/codex/tasks/task_e_68af9aa9979083288887a55a96b712df