### PR TITLE
Use parsed arguments for vehicle creation

### DIFF
--- a/pgttd/create_vehicle.py
+++ b/pgttd/create_vehicle.py
@@ -76,6 +76,7 @@ def insert_vehicle(
 
 def main() -> None:
     parser = argparse.ArgumentParser(description="Create a vehicle")
+    db.add_dsn_argument(parser)
     parser.add_argument("--x", type=int, default=0, help="Starting X coordinate")
     parser.add_argument("--y", type=int, default=0, help="Starting Y coordinate")
     parser.add_argument(
@@ -91,7 +92,8 @@ def main() -> None:
         default="[]",
         help="JSON description of cargo",
     )
-    args = db.parse_dsn(parser)
+    args = parser.parse_args()
+    db.parse_dsn(args)
 
     insert_vehicle(
         dsn=args.dsn,


### PR DESCRIPTION
## Summary
- Parse CLI args before validating DSN in `pgttd.create_vehicle`
- Add standard DSN option to the vehicle creation script

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68af9aa771248328a06194c903e8b6d1