### PR TITLE
Fix duplicate DSN argument in create_vehicle main

### DIFF
--- a/pgttd/create_vehicle.py
+++ b/pgttd/create_vehicle.py
@@ -5,6 +5,7 @@ import json
 
 from . import db
 
+
 def insert_vehicle(
     dsn: str,
     x: int,
@@ -95,7 +96,6 @@ def main() -> None:
 
     args = parser.parse_args()
     db.parse_dsn(args)
-    db.add_dsn_argument(parser)
 
     insert_vehicle(
         dsn=args.dsn,
@@ -111,4 +111,3 @@ def main() -> None:
 
 if __name__ == "__main__":  # pragma: no cover - script execution
     main()
-


### PR DESCRIPTION
## Summary
- fix duplicate `--dsn` argument in `pgttd.create_vehicle.main`
- ensure argument parsing no longer conflicts

## Testing
- `pre-commit run --files pgttd/create_vehicle.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af9c0ca7348328835193e2841807d8