### PR TITLE
refactor: wrap run_tick script

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@ connect to PostgreSQL. Install the dependencies with:
 pip install -r requirements.txt
 ```
 
-Scripts such as `scripts/run_tick.py` and `scripts/create_vehicle.py` expect a
-PostgreSQL connection string via the `--dsn` option or the `DATABASE_URL`
-environment variable.
+Utilities such as `python -m pgttd.run_tick` and `python -m pgttd.create_vehicle`
+expect a PostgreSQL connection string via the `--dsn` option or the
+`DATABASE_URL` environment variable.
 
 ## Schema
 

--- a/docs/procs.md
+++ b/docs/procs.md
@@ -20,12 +20,12 @@ CALL tick();
 ```
 
 ### Python wrapper
-The script [`scripts/run_tick.py`](../scripts/run_tick.py) calls `tick()` using
+The module [`pgttd.run_tick`](../pgttd/run_tick.py) calls `tick()` using
 [`psycopg`](https://www.psycopg.org/). Set the `DATABASE_URL` environment
 variable and run:
 
 ```bash
-python scripts/run_tick.py
+python -m pgttd.run_tick
 ```
 
 ## `economy_tick()`

--- a/scripts/run_tick.py
+++ b/scripts/run_tick.py
@@ -1,39 +1,10 @@
-"""Wrapper script to advance the game tick."""
+"""Command-line wrapper for :mod:`pgttd.run_tick`."""
 
-import argparse
-import logging
-import sys
-
-import pgttd.db as db
+from pgttd.run_tick import main
 
 
-def main() -> int:
-    """Call the ``tick`` stored procedure."""
-    parser = argparse.ArgumentParser(description="Advance the game tick")
-    db.add_dsn_argument(parser)
-    args = parser.parse_args()
-    db.parse_dsn(args)
-
-    conn = None
-    try:
-        with db.connect(args.dsn) as conn:
-            with conn.cursor() as cur:
-                cur.execute("CALL tick()")
-            conn.commit()
-        logging.info("tick() executed successfully")
-        return 0
-
-    except Exception:  # pragma: no cover - simple CLI logging
-        logging.exception("tick() execution failed")
-        if conn is not None:
-            try:
-                conn.rollback()
-            except Exception:
-                pass
-        return 1
-
-
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover - script execution
     import sys
 
     sys.exit(main())
+

--- a/tests/test_run_tick.py
+++ b/tests/test_run_tick.py
@@ -61,7 +61,7 @@ def test_main_success(monkeypatch):
         return conn
 
     monkeypatch.setattr(run_tick.db, "connect", fake_connect)
-    monkeypatch.setattr(sys, "argv", ["run_tick.py", "--dsn", DSN])
+    monkeypatch.setattr(sys, "argv", ["pgttd.run_tick", "--dsn", DSN])
 
     rc = run_tick.main()
 
@@ -77,7 +77,7 @@ def test_main_failure(monkeypatch):
     conn = DummyConnection(cursor)
 
     monkeypatch.setattr(run_tick.db, "connect", lambda dsn: conn)
-    monkeypatch.setattr(sys, "argv", ["run_tick.py", "--dsn", DSN])
+    monkeypatch.setattr(sys, "argv", ["pgttd.run_tick", "--dsn", DSN])
 
     rc = run_tick.main()
 


### PR DESCRIPTION
## Summary
- replace `scripts/run_tick.py` with a thin wrapper calling `pgttd.run_tick.main`
- document using `python -m pgttd.run_tick` instead of the script
- adjust tests to reference the module entry point

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68afb2d49a6c8328a58058f7176c740b