### PR TITLE
Simplify run_tick connection handling

### DIFF
--- a/pgttd/run_tick.py
+++ b/pgttd/run_tick.py
@@ -3,7 +3,6 @@
 import argparse
 import logging
 import sys
-from contextlib import ExitStack
 
 from . import db
 
@@ -15,10 +14,7 @@ def main() -> int:
     args, _ = parser.parse_known_args()
     db.parse_dsn(args)
 
-    with ExitStack() as stack:
-        conn_ctx = db.connect(args.dsn)
-        conn = stack.enter_context(conn_ctx) if hasattr(conn_ctx, "__enter__") else conn_ctx
-        stack.callback(getattr(conn, "close", lambda: None))
+    with db.connect(args.dsn) as conn:
         try:
             with conn.cursor() as cur:
                 cur.execute("CALL tick()")


### PR DESCRIPTION
## Summary
- use `with db.connect(...)` directly instead of `ExitStack` for connection handling in `run_tick`
- retain explicit commit/rollback logic around stored procedure call
- adjust `run_tick` tests for the simplified connection context

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68afb2d30bf08328bc1c74647c034fd1