### PR TITLE
Ensure UTF-8 encoding for generated schema and coverage CSV

### DIFF
--- a/scripts/generate_schema.py
+++ b/scripts/generate_schema.py
@@ -26,8 +26,9 @@ TABLE_ORDER = [
     "resource_industries",
 ]
 
+
 def main() -> None:
-    with SCHEMA_PATH.open("w") as schema:
+    with SCHEMA_PATH.open("w", encoding="utf-8") as schema:
         schema.write("-- Auto-generated; do not edit directly.\n\n")
         for name in TABLE_ORDER:
             path = TABLES_DIR / f"{name}.sql"
@@ -36,6 +37,7 @@ def main() -> None:
             if not text.endswith("\n"):
                 schema.write("\n")
             schema.write("\n")
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/postgres_coverage.py
+++ b/scripts/postgres_coverage.py
@@ -53,7 +53,7 @@ def collect_coverage(dsn: str) -> List[Tuple[str, float, float]]:
 
 
 def write_csv(rows: List[Tuple[str, float, float]], path: str) -> None:
-    with open(path, "w", newline="") as f:
+    with open(path, "w", newline="", encoding="utf-8") as f:
         writer = csv.writer(f)
         writer.writerow(["function", "statement_coverage", "branch_coverage"])
         writer.writerows(rows)


### PR DESCRIPTION
## Summary
- explicitly write schema.sql using UTF-8
- ensure postgres coverage CSV is written with UTF-8 encoding

## Testing
- `pre-commit run --files scripts/generate_schema.py scripts/postgres_coverage.py`
- `python - <<'PY'
from scripts.postgres_coverage import write_csv
import csv, os
rows=[("foo.bar", 0.75, 0.5)]
path='coverage_test.csv'
write_csv(rows, path)
with open(path, encoding='utf-8') as f:
    data=f.read()
print(data)
with open(path, newline='', encoding='utf-8') as f:
    r=list(csv.reader(f))
print(r)
os.remove(path)
PY`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68afb2ce9cd48328af3880a793b089f8