### PR TITLE
Reduce tile count in generator memory test

### DIFF
--- a/tests/test_renderer_memory.py
+++ b/tests/test_renderer_memory.py
@@ -1,6 +1,8 @@
 import types
 import tracemalloc
 
+import pytest
+
 from renderer.cli_viewer import render, Tile
 
 class DummyScreen:
@@ -12,7 +14,8 @@ class DummyScreen:
         pass
 
 
-def test_render_uses_less_memory_with_generator(monkeypatch):
+@pytest.mark.parametrize("N", [10_000])
+def test_render_uses_less_memory_with_generator(monkeypatch, N):
     dummy_curses = types.SimpleNamespace(
         COLOR_BLACK=0,
         COLOR_RED=1,
@@ -28,7 +31,6 @@ def test_render_uses_less_memory_with_generator(monkeypatch):
     monkeypatch.setattr("renderer.cli_viewer.curses", dummy_curses, raising=False)
 
     screen = DummyScreen()
-    N = 100000
 
     def generate_tiles(n):
         for i in range(n):


### PR DESCRIPTION
## Summary
- parameterize renderer memory test with `N` set to 10,000
- ensure test continues to validate generator uses less peak memory

## Testing
- `pytest tests/test_renderer_memory.py::test_render_uses_less_memory_with_generator -q`


------
https://chatgpt.com/codex/tasks/task_e_68afb2cab7ec83288343fe9b70eb517c