### PR TITLE
Validate PGPORT in CLI viewer config

### DIFF
--- a/renderer/cli_viewer.py
+++ b/renderer/cli_viewer.py
@@ -68,9 +68,15 @@ def load_config() -> dict[str, str]:
                 msg = f"Invalid JSON in config file '{cfg_path}': {exc.msg}"
                 raise RuntimeError(msg) from exc
 
+    pgport = os.environ.get("PGPORT", "5432")
+    try:
+        port = int(pgport)
+    except ValueError as exc:
+        raise RuntimeError(f"Invalid PGPORT value: {pgport}") from exc
+
     return {
         "host": os.environ.get("PGHOST", "localhost"),
-        "port": int(os.environ.get("PGPORT", 5432)),
+        "port": port,
         "dbname": os.environ.get("PGDATABASE", "pgttd"),
         "user": os.environ.get("PGUSER", "postgres"),
         "password": os.environ.get("PGPASSWORD", ""),

--- a/tests/test_cli_viewer_config.py
+++ b/tests/test_cli_viewer_config.py
@@ -8,3 +8,9 @@ def test_load_config_invalid_json(tmp_path, monkeypatch):
     monkeypatch.setenv("PGTTD_CONFIG", str(cfg))
     with pytest.raises(RuntimeError, match="Invalid JSON"):
         load_config()
+
+
+def test_load_config_invalid_pgport(monkeypatch):
+    monkeypatch.setenv("PGPORT", "not-a-number")
+    with pytest.raises(RuntimeError, match="Invalid PGPORT"):
+        load_config()


### PR DESCRIPTION
## Summary
- validate PGPORT environment variable and raise RuntimeError with invalid values
- test that load_config fails on non-numeric PGPORT

## Testing
- `pre-commit run --files renderer/cli_viewer.py tests/test_cli_viewer_config.py`
- `pytest tests/test_cli_viewer_config.py`


------
https://chatgpt.com/codex/tasks/task_e_68b0ad5ac65483288a09ca765e9c5f9e