### PR TITLE
Refactor create_vehicle CLI parsing

### DIFF
--- a/pgttd/create_vehicle.py
+++ b/pgttd/create_vehicle.py
@@ -75,7 +75,8 @@ def insert_vehicle(
         conn.commit()
 
 
-def main() -> None:
+def build_arg_parser() -> argparse.ArgumentParser:
+    """Return an argument parser configured for vehicle creation."""
     parser = argparse.ArgumentParser(description="Create a vehicle")
     db.add_dsn_argument(parser)
     parser.add_argument("--x", type=int, default=0, help="Starting X coordinate")
@@ -93,18 +94,25 @@ def main() -> None:
         default="[]",
         help="JSON description of cargo",
     )
+    return parser
 
+
+def main() -> None:
+    parser = build_arg_parser()
     args = parser.parse_args()
     db.parse_dsn(args)
 
-    insert_vehicle(
-        dsn=args.dsn,
-        x=args.x,
-        y=args.y,
-        schedule=args.schedule,
-        cargo=args.cargo,
-        company_id=args.company_id,
-    )
+    try:
+        insert_vehicle(
+            dsn=args.dsn,
+            x=args.x,
+            y=args.y,
+            schedule=args.schedule,
+            cargo=args.cargo,
+            company_id=args.company_id,
+        )
+    except ValueError as e:
+        raise SystemExit(str(e)) from e
 
     print("Inserted vehicle at", args.x, args.y)
 

--- a/scripts/create_vehicle.py
+++ b/scripts/create_vehicle.py
@@ -1,52 +1,11 @@
-"""Insert a sample vehicle for testing.
+"""Insert a sample vehicle for testing."""
 
-The script connects to a PostgreSQL database using standard libpq
-connection parameters. A JSON array of waypoints is inserted into the
-`schedule` column. Each waypoint must be an object with `x` and `y` keys.
-"""
-
-import argparse
-import sys
-
-import pgttd.db as db
-from pgttd.create_vehicle import insert_vehicle
+from pgttd.create_vehicle import main as _main
 
 
 def main() -> None:
-    parser = argparse.ArgumentParser(description="Create a vehicle")
-    db.add_dsn_argument(parser)
-    parser.add_argument("--x", type=int, default=0, help="Starting X coordinate")
-    parser.add_argument("--y", type=int, default=0, help="Starting Y coordinate")
-    parser.add_argument(
-        "--schedule",
-        type=str,
-        default="[]",
-        help='JSON array of waypoints, e.g. [{"x":0,"y":0},{"x":5,"y":5}]',
-    )
-    parser.add_argument("--company-id", type=int, default=None)
-    parser.add_argument(
-        "--cargo",
-        type=str,
-        default="[]",
-        help="JSON description of cargo",
-    )
-    args = parser.parse_args()
-    db.parse_dsn(args)
-
-    try:
-        insert_vehicle(
-            dsn=args.dsn,
-            x=args.x,
-            y=args.y,
-            schedule=args.schedule,
-            cargo=args.cargo,
-            company_id=args.company_id,
-        )
-    except ValueError as e:
-        print(e, file=sys.stderr)
-        sys.exit(1)
-
-    print("Inserted vehicle at", args.x, args.y)
+    """Entry point for the ``create_vehicle`` script."""
+    _main()
 
 
 if __name__ == "__main__":

--- a/tests/test_create_vehicle.py
+++ b/tests/test_create_vehicle.py
@@ -4,8 +4,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from scripts import create_vehicle
-from pgttd import create_vehicle as cv_module
+from pgttd import create_vehicle
 
 DSN = "postgresql://example"
 
@@ -54,7 +53,7 @@ def test_main_success(monkeypatch, capsys):
         assert dsn == DSN
         return conn
 
-    monkeypatch.setattr(cv_module.db, "connect", fake_connect)
+    monkeypatch.setattr(create_vehicle.db, "connect", fake_connect)
 
     monkeypatch.setattr(
         sys,
@@ -92,9 +91,9 @@ def test_main_success(monkeypatch, capsys):
     assert f"Inserted vehicle at 1 2" in capsys.readouterr().out
 
 
-def test_invalid_schedule_json(monkeypatch, capsys):
+def test_invalid_schedule_json(monkeypatch):
     connect_mock = MagicMock()
-    monkeypatch.setattr(cv_module.db, "connect", connect_mock)
+    monkeypatch.setattr(create_vehicle.db, "connect", connect_mock)
     monkeypatch.setattr(
         sys,
         "argv",
@@ -103,23 +102,7 @@ def test_invalid_schedule_json(monkeypatch, capsys):
 
     with pytest.raises(SystemExit) as exc:
         create_vehicle.main()
-    assert exc.value.code == 1
-    assert "Invalid JSON for --schedule" in capsys.readouterr().err
-
-    connect_mock.assert_not_called()
-
-
-def test_module_main_invalid_schedule_json(monkeypatch):
-    connect_mock = MagicMock()
-    monkeypatch.setattr(cv_module.db, "connect", connect_mock)
-    monkeypatch.setattr(
-        sys,
-        "argv",
-        ["create_vehicle.py", "--dsn", DSN, "--schedule", "not json"],
-    )
-
-    with pytest.raises(ValueError):
-        cv_module.main()
+    assert "Invalid JSON for --schedule" in str(exc.value)
 
     connect_mock.assert_not_called()
 
@@ -133,31 +116,31 @@ def test_module_main_invalid_schedule_json(monkeypatch):
 )
 def test_insert_vehicle_cargo_missing_required_keys(monkeypatch, cargo):
     connect_mock = MagicMock()
-    monkeypatch.setattr(cv_module.db, "connect", connect_mock)
+    monkeypatch.setattr(create_vehicle.db, "connect", connect_mock)
 
     with pytest.raises(ValueError):
-        cv_module.insert_vehicle(DSN, 0, 0, "[]", cargo, None)
+        create_vehicle.insert_vehicle(DSN, 0, 0, "[]", cargo, None)
 
     connect_mock.assert_not_called()
 
 
 def test_insert_vehicle_cargo_resource_wrong_type(monkeypatch):
     connect_mock = MagicMock()
-    monkeypatch.setattr(cv_module.db, "connect", connect_mock)
+    monkeypatch.setattr(create_vehicle.db, "connect", connect_mock)
     cargo = json.dumps([{"resource": 5, "amount": 3}])
 
     with pytest.raises(ValueError):
-        cv_module.insert_vehicle(DSN, 0, 0, "[]", cargo, None)
+        create_vehicle.insert_vehicle(DSN, 0, 0, "[]", cargo, None)
 
     connect_mock.assert_not_called()
 
 
 def test_insert_vehicle_cargo_amount_non_integer(monkeypatch):
     connect_mock = MagicMock()
-    monkeypatch.setattr(cv_module.db, "connect", connect_mock)
+    monkeypatch.setattr(create_vehicle.db, "connect", connect_mock)
     cargo = json.dumps([{"resource": "wood", "amount": "three"}])
 
     with pytest.raises(ValueError):
-        cv_module.insert_vehicle(DSN, 0, 0, "[]", cargo, None)
+        create_vehicle.insert_vehicle(DSN, 0, 0, "[]", cargo, None)
 
     connect_mock.assert_not_called()


### PR DESCRIPTION
## Summary
- share a build_arg_parser helper for create_vehicle
- handle argument errors via SystemExit in create_vehicle.main
- simplify create_vehicle script to call library entry point
- adjust tests to use unified entry point

## Testing
- `pre-commit run --files pgttd/create_vehicle.py scripts/create_vehicle.py tests/test_create_vehicle.py`
- `pytest tests/test_create_vehicle.py`


------
https://chatgpt.com/codex/tasks/task_e_68b0ad57700c832897addd68b1247514