### PR TITLE
Refactor renderer color cache names

### DIFF
--- a/renderer/cli_viewer.py
+++ b/renderer/cli_viewer.py
@@ -114,32 +114,32 @@ def advance_tick(conn) -> None:
 # ---------------------------------------------------------------------------
 
 
-COLOUR_CACHE: dict[str, int] = {}
+COLOR_CACHE: dict[str, int] = {}
 
 
-def colour_pair(colour: str, cache: dict[str, int] | None = None) -> int:
+def color_pair(color: str, cache: dict[str, int] | None = None) -> int:
     """Return a curses color pair for a color name."""
 
     if cache is None:
-        cache = COLOUR_CACHE
-    colour = colour.lower()
-    if colour not in cache:
+        cache = COLOR_CACHE
+    color = color.lower()
+    if color not in cache:
         idx = len(cache) + 1
-        base = COLOR_NAMES.get(colour, curses.COLOR_WHITE)
+        base = COLOR_NAMES.get(color, curses.COLOR_WHITE)
         curses.init_pair(idx, base, curses.COLOR_BLACK)
-        cache[colour] = idx
-    return curses.color_pair(cache[colour])
+        cache[color] = idx
+    return curses.color_pair(cache[color])
 
 
-def render(stdscr, tiles: Iterable[Tile], colour_cache: dict[str, int] | None = None) -> None:
+def render(stdscr, tiles: Iterable[Tile], color_cache: dict[str, int] | None = None) -> None:
     """Render tiles onto the curses screen."""
 
-    if colour_cache is None:
-        colour_cache = COLOUR_CACHE
+    if color_cache is None:
+        color_cache = COLOR_CACHE
     stdscr.erase()
     for tile in tiles:
         try:
-            stdscr.addch(tile.y, tile.x, tile.ch, colour_pair(tile.color, colour_cache))
+            stdscr.addch(tile.y, tile.x, tile.ch, color_pair(tile.color, color_cache))
         except curses.error:
             # Ignore tiles outside the screen.
             pass
@@ -164,7 +164,7 @@ def main(stdscr, dsn: str | None, refresh: float, step: bool) -> None:
     try:
         while True:
             tiles = fetch_tiles(conn)
-            render(stdscr, tiles, COLOUR_CACHE)
+            render(stdscr, tiles, COLOR_CACHE)
             ch = stdscr.getch()
             if ch == ord("q"):
                 break

--- a/tests/test_renderer_memory.py
+++ b/tests/test_renderer_memory.py
@@ -57,7 +57,7 @@ def test_render_uses_less_memory_with_generator(monkeypatch, N):
     assert peak_gen < peak_list
 
 
-def test_render_reuses_colour_cache(monkeypatch):
+def test_render_reuses_color_cache(monkeypatch):
     calls = []
     dummy_curses = types.SimpleNamespace(
         COLOR_BLACK=0,


### PR DESCRIPTION
## Summary
- rename colour cache to color cache to standardize spelling
- adjust renderer helpers to use `color` naming
- align tests with new color-based terminology

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b0e9a1e3948328b0d07e49143fe4b4