### PR TITLE
Validate non-negative cargo amounts

### DIFF
--- a/pgttd/create_vehicle.py
+++ b/pgttd/create_vehicle.py
@@ -48,6 +48,10 @@ def validate_cargo(cargo: str) -> list[dict[str, object]]:
             raise ValueError(f"Cargo entry {idx} key 'resource' must be a string")
         if not isinstance(item["amount"], int):
             raise ValueError(f"Cargo entry {idx} key 'amount' must be an integer")
+        if item["amount"] < 0:
+            raise ValueError(
+                f"Cargo entry {idx} key 'amount' must be non-negative"
+            )
     return cargo_obj
 
 

--- a/tests/test_create_vehicle.py
+++ b/tests/test_create_vehicle.py
@@ -165,6 +165,10 @@ def test_validate_cargo_success():
             '[{"resource":"wood","amount":"3"}]',
             "Cargo entry 0 key 'amount' must be an integer",
         ),
+        (
+            '[{"resource":"wood","amount":-1}]',
+            "Cargo entry 0 key 'amount' must be non-negative",
+        ),
     ],
 )
 def test_validate_cargo_errors(cargo, msg):
@@ -204,6 +208,17 @@ def test_insert_vehicle_cargo_amount_non_integer(monkeypatch):
     connect_mock = MagicMock()
     monkeypatch.setattr(create_vehicle.db, "connect", connect_mock)
     cargo = json.dumps([{"resource": "wood", "amount": "three"}])
+
+    with pytest.raises(ValueError):
+        create_vehicle.insert_vehicle(DSN, 0, 0, "[]", cargo, None)
+
+    connect_mock.assert_not_called()
+
+
+def test_insert_vehicle_cargo_amount_negative(monkeypatch):
+    connect_mock = MagicMock()
+    monkeypatch.setattr(create_vehicle.db, "connect", connect_mock)
+    cargo = json.dumps([{"resource": "wood", "amount": -1}])
 
     with pytest.raises(ValueError):
         create_vehicle.insert_vehicle(DSN, 0, 0, "[]", cargo, None)


### PR DESCRIPTION
## Summary
- reject cargo entries with negative amounts
- add tests for negative cargo amounts

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b0e9a368dc8328af120b0c4566758e