### PR TITLE
Handle psycopg errors explicitly

### DIFF
--- a/pgttd/run_tick.py
+++ b/pgttd/run_tick.py
@@ -4,6 +4,8 @@ import argparse
 import logging
 import sys
 
+import psycopg
+
 from . import db
 
 
@@ -21,7 +23,7 @@ def main() -> int:
             conn.commit()
             logging.info("tick() executed successfully")
             return 0
-        except Exception:  # pragma: no cover - simple CLI logging
+        except psycopg.Error:  # pragma: no cover - simple CLI logging
             logging.exception("tick() execution failed")
             conn.rollback()
             return 1

--- a/renderer/cli_viewer.py
+++ b/renderer/cli_viewer.py
@@ -103,7 +103,7 @@ def advance_tick(conn) -> None:
         try:
             cur.execute("CALL tick()")
             conn.commit()
-        except Exception:
+        except psycopg.Error:
             conn.rollback()
             logger.exception("Failed to advance simulation tick")
             raise
@@ -131,7 +131,9 @@ def colour_pair(colour: str, cache: dict[str, int] | None = None) -> int:
     return curses.color_pair(cache[colour])
 
 
-def render(stdscr, tiles: Iterable[Tile], colour_cache: dict[str, int] | None = None) -> None:
+def render(
+    stdscr, tiles: Iterable[Tile], colour_cache: dict[str, int] | None = None
+) -> None:
     """Render tiles onto the curses screen."""
 
     if colour_cache is None:
@@ -171,7 +173,7 @@ def main(stdscr, dsn: str | None, refresh: float, step: bool) -> None:
             if not step or ch == ord("t"):
                 try:
                     advance_tick(conn)
-                except Exception:
+                except psycopg.Error:
                     logger.error("Tick advancement failed; exiting viewer")
                     break
             time.sleep(refresh)


### PR DESCRIPTION
## Summary
- Catch only `psycopg.Error` when running `tick()` via CLI and viewer
- Allow non-psycopg exceptions to propagate
- Adjust tests to expect psycopg errors and add coverage for unexpected failures

## Testing
- `pre-commit run --files pgttd/run_tick.py renderer/cli_viewer.py tests/test_run_tick.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b0e9a5e9f8832883b2dd646a5cab8f