### PR TITLE
Rename colour_cache argument to color_cache

### DIFF
--- a/renderer/cli_viewer.py
+++ b/renderer/cli_viewer.py
@@ -132,7 +132,7 @@ def color_pair(color: str, cache: dict[str, int] | None = None) -> int:
 
 
 def render(
-    stdscr, tiles: Iterable[Tile], colour_cache: dict[str, int] | None = None
+    stdscr, tiles: Iterable[Tile], color_cache: dict[str, int] | None = None
 ) -> None:
     """Render tiles onto the curses screen."""
 
@@ -166,7 +166,7 @@ def main(stdscr, dsn: str | None, refresh: float, step: bool) -> None:
     try:
         while True:
             tiles = fetch_tiles(conn)
-            render(stdscr, tiles, COLOR_CACHE)
+            render(stdscr, tiles, color_cache=COLOR_CACHE)
             ch = stdscr.getch()
             if ch == ord("q"):
                 break

--- a/tests/test_renderer_memory.py
+++ b/tests/test_renderer_memory.py
@@ -38,11 +38,11 @@ def test_render_uses_less_memory_with_generator(monkeypatch, N):
 
     def run_list():
         tiles = list(generate_tiles(N))
-        render(screen, tiles, {})
+        render(screen, tiles, color_cache={})
 
     def run_gen():
         tiles = generate_tiles(N)
-        render(screen, tiles, {})
+        render(screen, tiles, color_cache={})
 
     tracemalloc.start()
     run_list()
@@ -77,7 +77,7 @@ def test_render_reuses_color_cache(monkeypatch):
     tiles = [Tile(x=0, y=0, ch="@", color="white")]
     cache: dict[str, int] = {}
 
-    render(screen, tiles, cache)
-    render(screen, tiles, cache)
+    render(screen, tiles, color_cache=cache)
+    render(screen, tiles, color_cache=cache)
 
     assert len(calls) == 1


### PR DESCRIPTION
## Summary
- rename `colour_cache` argument to `color_cache` in CLI renderer
- update render call sites and tests to match new argument name

## Testing
- `pytest tests/test_renderer_memory.py -q`
- `pytest -q` *(fails: tests/test_create_vehicle.py::test_main_defaults)*

------
https://chatgpt.com/codex/tasks/task_e_68b9b79af8b48328b655f6bcfd13f626