### PR TITLE
refactor: centralize dummy db test helpers

### DIFF
--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,0 +1,47 @@
+import psycopg
+
+
+class DummyCursor:
+    def __init__(self, should_fail: bool = False):
+        self.should_fail = should_fail
+        self.executed = None
+        self.sql = None
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        pass
+
+    def execute(self, sql, params=None):
+        if self.should_fail:
+            raise psycopg.Error("boom")
+        self.sql = sql
+        if params is not None:
+            self.executed = (sql, params)
+
+
+class DummyConnection:
+    def __init__(self, cursor: DummyCursor):
+        self.cursor_obj = cursor
+        self.committed = False
+        self.rolled_back = False
+        self.closed = False
+
+    def cursor(self):
+        return self.cursor_obj
+
+    def commit(self):
+        self.committed = True
+
+    def rollback(self):
+        self.rolled_back = True
+
+    def close(self):
+        self.closed = True
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        self.close()

--- a/tests/test_create_vehicle.py
+++ b/tests/test_create_vehicle.py
@@ -6,6 +6,7 @@ import pytest
 from psycopg.types.json import Json
 
 from pgttd import create_vehicle
+from tests.helpers import DummyCursor, DummyConnection
 
 # The original tests reference a ``cv_module`` variable but never assign it.
 #
@@ -17,42 +18,6 @@ from pgttd import create_vehicle
 cv_module = create_vehicle
 
 DSN = "postgresql://example"
-
-
-class DummyCursor:
-    def __init__(self):
-        self.executed = None
-
-    def __enter__(self):
-        return self
-
-    def __exit__(self, exc_type, exc, tb):
-        pass
-
-    def execute(self, sql, params):
-        self.executed = (sql, params)
-
-
-class DummyConnection:
-    def __init__(self, cursor: DummyCursor):
-        self.cursor_obj = cursor
-        self.committed = False
-        self.closed = False
-
-    def cursor(self):
-        return self.cursor_obj
-
-    def commit(self):
-        self.committed = True
-
-    def close(self):
-        self.closed = True
-
-    def __enter__(self):
-        return self
-
-    def __exit__(self, exc_type, exc, tb):
-        self.close()
 
 
 def test_main_success(monkeypatch, capsys):

--- a/tests/test_run_tick.py
+++ b/tests/test_run_tick.py
@@ -5,51 +5,9 @@ import psycopg
 import pytest
 
 from pgttd import run_tick
+from tests.helpers import DummyCursor, DummyConnection
 
 DSN = "postgresql://example"
-
-
-class DummyCursor:
-    def __init__(self, should_fail: bool = False):
-        self.should_fail = should_fail
-        self.sql = None
-
-    def __enter__(self):
-        return self
-
-    def __exit__(self, exc_type, exc, tb):
-        pass
-
-    def execute(self, sql: str):
-        if self.should_fail:
-            raise psycopg.Error("boom")
-        self.sql = sql
-
-
-class DummyConnection:
-    def __init__(self, cursor: DummyCursor):
-        self.cursor_obj = cursor
-        self.committed = False
-        self.rolled_back = False
-        self.closed = False
-
-    def __enter__(self):
-        return self
-
-    def __exit__(self, exc_type, exc, tb):
-        self.close()
-
-    def cursor(self):
-        return self.cursor_obj
-
-    def commit(self):
-        self.committed = True
-
-    def rollback(self):
-        self.rolled_back = True
-
-    def close(self):
-        self.closed = True
 
 
 def test_main_success(monkeypatch):


### PR DESCRIPTION
## Summary
- DRY out DummyCursor and DummyConnection into tests/helpers
- Import shared test helpers in create_vehicle and run_tick tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b9b7986e688328966d39e18c28f659