### PR TITLE
Handle None values in sprite SQL quoting

### DIFF
--- a/tests/test_generate_sprites.py
+++ b/tests/test_generate_sprites.py
@@ -42,6 +42,7 @@ def test_quote_sql_handles_various_types():
     assert generate_sprites.quote_sql("O'Reilly") == "'O''Reilly'"
     assert generate_sprites.quote_sql(42) == "'42'"
     assert generate_sprites.quote_sql(Path("a'b")) == "'a''b'"
+    assert generate_sprites.quote_sql(None) == "NULL"
 
 
 def test_main_writes_expected_file(tmp_path, monkeypatch, capsys):

--- a/tools/generate_sprites.py
+++ b/tools/generate_sprites.py
@@ -29,6 +29,9 @@ def quote_sql(value: Any) -> str:
     and ensures we can safely escape any single quotes.
     """
 
+    if value is None:
+        return "NULL"
+
     text = str(value)
     return "'" + text.replace("'", "''") + "'"
 


### PR DESCRIPTION
## Summary
- support `None` in `quote_sql` by emitting `NULL` without quotes
- test `quote_sql` against `None` values

## Testing
- `pytest tests/test_generate_sprites.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b9b7972f688328bcd2e7c7ce00b4c6