### PR TITLE
Handle missing PGTTD config file

### DIFF
--- a/renderer/cli_viewer.py
+++ b/renderer/cli_viewer.py
@@ -60,7 +60,11 @@ def load_config() -> dict[str, str]:
     """Return connection parameters from environment or config file."""
 
     cfg_path = os.environ.get("PGTTD_CONFIG")
-    if cfg_path and os.path.exists(cfg_path):
+    if cfg_path:
+        if not os.path.exists(cfg_path):
+            raise RuntimeError(
+                f"Config file '{cfg_path}' referenced by PGTTD_CONFIG does not exist"
+            )
         with open(cfg_path, "r", encoding="utf8") as cfg:
             try:
                 return json.load(cfg)

--- a/tests/test_cli_viewer_config.py
+++ b/tests/test_cli_viewer_config.py
@@ -10,6 +10,12 @@ def test_load_config_invalid_json(tmp_path, monkeypatch):
         load_config()
 
 
+def test_load_config_missing_config_file(monkeypatch):
+    monkeypatch.setenv("PGTTD_CONFIG", "/nonexistent/config.json")
+    with pytest.raises(RuntimeError, match="does not exist"):
+        load_config()
+
+
 def test_load_config_invalid_pgport(monkeypatch):
     monkeypatch.setenv("PGPORT", "not-a-number")
     with pytest.raises(RuntimeError, match="Invalid PGPORT"):


### PR DESCRIPTION
## Summary
- raise a runtime error when PGTTD_CONFIG points to a missing file
- cover the new failure mode with a unit test

## Testing
- pytest tests/test_cli_viewer_config.py

------
https://chatgpt.com/codex/tasks/task_e_68d83b49d390832892a8cb07b1ced25a