### PR TITLE
Validate CLI refresh interval

### DIFF
--- a/renderer/cli_viewer.py
+++ b/renderer/cli_viewer.py
@@ -153,9 +153,24 @@ def render(
 # ---------------------------------------------------------------------------
 
 
+def positive_float(value: str) -> float:
+    """Return ``value`` as a positive float or raise an ArgumentTypeError."""
+
+    try:
+        parsed = float(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("Refresh interval must be a number") from exc
+    if parsed <= 0:
+        msg = "Refresh interval must be greater than zero"
+        raise argparse.ArgumentTypeError(msg)
+    return parsed
+
+
 def main(stdscr, dsn: str | None, refresh: float, step: bool) -> None:
     """Render the simulation in a curses window."""
 
+    if refresh <= 0:
+        raise ValueError("Refresh interval must be greater than zero")
     curses.curs_set(0)
     stdscr.nodelay(True)
     if dsn:
@@ -176,6 +191,8 @@ def main(stdscr, dsn: str | None, refresh: float, step: bool) -> None:
                 except psycopg.Error:
                     logger.error("Tick advancement failed; exiting viewer")
                     break
+            if refresh <= 0:
+                raise ValueError("Refresh interval must be greater than zero")
             time.sleep(refresh)
     finally:
         conn.close()
@@ -187,7 +204,7 @@ if __name__ == "__main__":
     db.add_dsn_argument(parser)
     parser.add_argument(
         "--refresh",
-        type=float,
+        type=positive_float,
         default=0.5,
         help="delay between screen updates in seconds",
     )

--- a/tests/test_cli_viewer_refresh.py
+++ b/tests/test_cli_viewer_refresh.py
@@ -1,0 +1,27 @@
+import argparse
+
+import pytest
+
+import renderer.cli_viewer as cli_viewer
+
+
+class DummyStdScr:
+    def nodelay(self, flag: bool) -> None:
+        self.nodelay_flag = flag
+
+
+def test_positive_float_rejects_non_positive_values():
+    for value in ["0", "0.0", "-1", "-0.5"]:
+        with pytest.raises(argparse.ArgumentTypeError):
+            cli_viewer.positive_float(value)
+
+
+def test_positive_float_accepts_positive_value():
+    assert cli_viewer.positive_float("0.1") == pytest.approx(0.1)
+
+
+def test_main_rejects_invalid_refresh(monkeypatch):
+    stdscr = DummyStdScr()
+
+    with pytest.raises(ValueError, match="Refresh interval must be greater than zero"):
+        cli_viewer.main(stdscr, dsn=None, refresh=0, step=False)


### PR DESCRIPTION
## Summary
- add a positive float validator for the CLI viewer refresh argument
- guard the curses main loop against invalid refresh values
- add tests covering refresh validation and main loop handling

## Testing
- pytest tests/test_cli_viewer_refresh.py

------
https://chatgpt.com/codex/tasks/task_e_68d83b4933f08328ba6fed193ef1243d