### PR TITLE
Handle database errors in create_vehicle CLI

### DIFF
--- a/pgttd/create_vehicle.py
+++ b/pgttd/create_vehicle.py
@@ -3,6 +3,8 @@
 import argparse
 import json
 
+import psycopg
+
 from psycopg.types.json import Json
 
 from . import db
@@ -130,6 +132,8 @@ def main() -> None:
         )
     except ValueError as e:
         raise SystemExit(str(e)) from e
+    except psycopg.Error as e:
+        raise SystemExit(f"Database error: {e}") from e
 
     print("Inserted vehicle at", args.x, args.y)
 

--- a/tests/test_create_vehicle.py
+++ b/tests/test_create_vehicle.py
@@ -3,6 +3,7 @@ import sys
 from unittest.mock import MagicMock
 
 import pytest
+import psycopg
 from psycopg.types.json import Json
 
 from pgttd import create_vehicle
@@ -91,6 +92,22 @@ def test_main_defaults(monkeypatch, capsys):
     assert conn.committed
     assert conn.closed
     assert f"Inserted vehicle at 1 1" in capsys.readouterr().out
+
+
+def test_main_database_error(monkeypatch):
+    error = psycopg.Error("boom")
+
+    def fake_insert_vehicle(**_kwargs):
+        raise error
+
+    monkeypatch.setattr(create_vehicle, "insert_vehicle", fake_insert_vehicle)
+    monkeypatch.setattr(sys, "argv", ["create_vehicle.py", "--dsn", DSN])
+
+    with pytest.raises(SystemExit) as exc:
+        create_vehicle.main()
+
+    assert str(exc.value) == "Database error: boom"
+    assert exc.value.code != 0
 
 
 def test_invalid_schedule_json(monkeypatch):


### PR DESCRIPTION
## Summary
- catch psycopg database exceptions in the create_vehicle CLI and surface a concise error message
- add a test that simulates an insert failure to ensure the CLI exits cleanly

## Testing
- pytest tests/test_create_vehicle.py

------
https://chatgpt.com/codex/tasks/task_e_68d83b4b4ee083289dbbbad3a7084876