### PR TITLE
Validate CLI viewer config input

### DIFF
--- a/renderer/cli_viewer.py
+++ b/renderer/cli_viewer.py
@@ -56,18 +56,7 @@ COLOR_NAMES = {
 }
 
 
-def load_config() -> dict[str, str]:
-    """Return connection parameters from environment or config file."""
-
-    cfg_path = os.environ.get("PGTTD_CONFIG")
-    if cfg_path and os.path.exists(cfg_path):
-        with open(cfg_path, "r", encoding="utf8") as cfg:
-            try:
-                return json.load(cfg)
-            except json.JSONDecodeError as exc:
-                msg = f"Invalid JSON in config file '{cfg_path}': {exc.msg}"
-                raise RuntimeError(msg) from exc
-
+def _load_env_defaults() -> dict[str, str | int]:
     pgport = os.environ.get("PGPORT", "5432")
     try:
         port = int(pgport)
@@ -81,6 +70,65 @@ def load_config() -> dict[str, str]:
         "user": os.environ.get("PGUSER", "postgres"),
         "password": os.environ.get("PGPASSWORD", ""),
     }
+
+
+def _coerce_port(value: object, source: str) -> int:
+    if isinstance(value, bool):
+        raise RuntimeError(
+            f"Config file '{source}' field 'port' must be an integer value"
+        )
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str):
+        try:
+            return int(value)
+        except ValueError as exc:
+            msg = f"Config file '{source}' field 'port' must be an integer value"
+            raise RuntimeError(msg) from exc
+    raise RuntimeError(f"Config file '{source}' field 'port' must be an integer value")
+
+
+def load_config() -> dict[str, str | int]:
+    """Return connection parameters from environment or config file."""
+
+    defaults = _load_env_defaults()
+
+    cfg_path = os.environ.get("PGTTD_CONFIG")
+    if cfg_path and os.path.exists(cfg_path):
+        with open(cfg_path, "r", encoding="utf8") as cfg:
+            try:
+                data = json.load(cfg)
+            except json.JSONDecodeError as exc:
+                msg = f"Invalid JSON in config file '{cfg_path}': {exc.msg}"
+                raise RuntimeError(msg) from exc
+
+        if not isinstance(data, dict):
+            raise RuntimeError(
+                "Config file must contain a JSON object mapping connection fields to values"
+            )
+
+        config = defaults.copy()
+        allowed_fields = set(defaults)
+        for key, value in data.items():
+            if not isinstance(key, str):
+                raise RuntimeError(
+                    "Config file keys must be strings representing connection fields"
+                )
+            if key not in allowed_fields:
+                raise RuntimeError(
+                    f"Config file contains unsupported connection field '{key}'"
+                )
+            if key == "port":
+                config[key] = _coerce_port(value, cfg_path)
+            else:
+                if not isinstance(value, str):
+                    raise RuntimeError(
+                        f"Config file '{cfg_path}' field '{key}' must be a string value"
+                    )
+                config[key] = value
+        return config
+
+    return defaults
 
 
 def fetch_tiles(conn) -> Iterable[Tile]:

--- a/tests/test_cli_viewer_config.py
+++ b/tests/test_cli_viewer_config.py
@@ -1,3 +1,5 @@
+import json
+
 import pytest
 from renderer.cli_viewer import load_config
 
@@ -13,4 +15,36 @@ def test_load_config_invalid_json(tmp_path, monkeypatch):
 def test_load_config_invalid_pgport(monkeypatch):
     monkeypatch.setenv("PGPORT", "not-a-number")
     with pytest.raises(RuntimeError, match="Invalid PGPORT"):
+        load_config()
+
+
+def test_load_config_requires_mapping(tmp_path, monkeypatch):
+    cfg = tmp_path / "config.json"
+    cfg.write_text(json.dumps(["host", "localhost"]), encoding="utf8")
+    monkeypatch.setenv("PGTTD_CONFIG", str(cfg))
+    with pytest.raises(RuntimeError, match="JSON object"):
+        load_config()
+
+
+def test_load_config_rejects_unsupported_field(tmp_path, monkeypatch):
+    cfg = tmp_path / "config.json"
+    cfg.write_text(json.dumps({"dsn": "postgresql://"}), encoding="utf8")
+    monkeypatch.setenv("PGTTD_CONFIG", str(cfg))
+    with pytest.raises(RuntimeError, match="unsupported connection field"):
+        load_config()
+
+
+def test_load_config_requires_string_values(tmp_path, monkeypatch):
+    cfg = tmp_path / "config.json"
+    cfg.write_text(json.dumps({"host": 123}), encoding="utf8")
+    monkeypatch.setenv("PGTTD_CONFIG", str(cfg))
+    with pytest.raises(RuntimeError, match="must be a string value"):
+        load_config()
+
+
+def test_load_config_validates_port(tmp_path, monkeypatch):
+    cfg = tmp_path / "config.json"
+    cfg.write_text(json.dumps({"port": "invalid"}), encoding="utf8")
+    monkeypatch.setenv("PGTTD_CONFIG", str(cfg))
+    with pytest.raises(RuntimeError, match="field 'port' must be an integer"):
         load_config()


### PR DESCRIPTION
## Summary
- validate CLI viewer config files to ensure mapping structure, supported keys, and string values while coercing the port to an integer
- reuse environment defaults when loading configs and raise actionable RuntimeErrors for invalid inputs
- extend CLI viewer config tests to cover malformed structures and type mismatches

## Testing
- pytest tests/test_cli_viewer_config.py

------
https://chatgpt.com/codex/tasks/task_e_68d83b4a298c8328a8f934017dea8065